### PR TITLE
feat: improve lift selection controls

### DIFF
--- a/fabric/src/main/java/top/xfunny/core/data/YteData.java
+++ b/fabric/src/main/java/top/xfunny/core/data/YteData.java
@@ -17,7 +17,8 @@ public abstract class YteData {
                         config.getId(), config.getUpSpeed(), config.getDownSpeed(),
                         config.getUpAcceleration(), config.getDownAcceleration(), config.getAdoDistance(),
                         config.getLevellingDistance(), config.getLevellingSpeed(), config.getMotionProfile(),
-                        config.isDoorHoldEnabled());
+                        config.isDoorHoldEnabled(), config.getDoorButtonLightMode(), config.getFloorCancelMode(),
+                        config.isFloorCancelWhileMovingAllowed());
             });
         } catch (Exception e) {
             YteCoreLogger.error("YteData sync error", e);

--- a/fabric/src/main/java/top/xfunny/core/data/YteLiftConfig.java
+++ b/fabric/src/main/java/top/xfunny/core/data/YteLiftConfig.java
@@ -2,6 +2,8 @@ package top.xfunny.core.data;
 
 import org.mtr.core.serializer.ReaderBase;
 import top.xfunny.core.generated.data.YteLiftConfigSchema;
+import top.xfunny.mod.LiftDoorButtonLightMode;
+import top.xfunny.mod.LiftFloorCancelMode;
 import top.xfunny.mod.LiftMotionProfile;
 
 public class YteLiftConfig extends YteLiftConfigSchema {
@@ -30,8 +32,18 @@ public class YteLiftConfig extends YteLiftConfigSchema {
     public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             LiftMotionProfile motionProfile, boolean doorHoldEnabled) {
+        this(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                LiftDoorButtonLightMode.MOMENTARY, LiftFloorCancelMode.DOUBLE_CLICK, false);
+    }
+
+    public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            LiftMotionProfile motionProfile, boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode,
+            LiftFloorCancelMode floorCancelMode, boolean floorCancelWhileMoving) {
         super(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
-                adoDistance, levellingDistance, levellingSpeed, motionProfile.name(), doorHoldEnabled);
+                adoDistance, levellingDistance, levellingSpeed, motionProfile.name(), doorHoldEnabled,
+                doorButtonLightMode.name(), floorCancelMode.name(), floorCancelWhileMoving);
     }
 
     public YteLiftConfig(ReaderBase readerBase) {
@@ -66,6 +78,16 @@ public class YteLiftConfig extends YteLiftConfigSchema {
 
     public boolean isDoorHoldEnabled() { return doorHoldEnabled; }
 
+    public LiftDoorButtonLightMode getDoorButtonLightMode() {
+        return LiftDoorButtonLightMode.fromSerializedName(doorButtonLightMode);
+    }
+
+    public LiftFloorCancelMode getFloorCancelMode() {
+        return LiftFloorCancelMode.fromSerializedName(floorCancelMode);
+    }
+
+    public boolean isFloorCancelWhileMovingAllowed() { return floorCancelWhileMoving; }
+
     public void setSpeed(double speed) {
         this.speed = clamp(speed, MIN_SPEED, MAX_SPEED);
     }
@@ -81,6 +103,18 @@ public class YteLiftConfig extends YteLiftConfigSchema {
     public void setLevellingSpeed(double levellingSpeed) { this.levellingSpeed = clamp(levellingSpeed, MIN_LEVELLING_SPEED, MAX_LEVELLING_SPEED); }
 
     public void setDoorHoldEnabled(boolean doorHoldEnabled) { this.doorHoldEnabled = doorHoldEnabled; }
+
+    public void setDoorButtonLightMode(LiftDoorButtonLightMode doorButtonLightMode) {
+        this.doorButtonLightMode = doorButtonLightMode.name();
+    }
+
+    public void setFloorCancelMode(LiftFloorCancelMode floorCancelMode) {
+        this.floorCancelMode = floorCancelMode.name();
+    }
+
+    public void setFloorCancelWhileMovingAllowed(boolean floorCancelWhileMoving) {
+        this.floorCancelWhileMoving = floorCancelWhileMoving;
+    }
 
     private static double clamp(double value, double min, double max) {
         return Math.max(min, Math.min(max, value));

--- a/fabric/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
+++ b/fabric/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
@@ -17,6 +17,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     protected double levellingDistance;
     protected double levellingSpeed;
     protected boolean doorHoldEnabled;
+    protected String doorButtonLightMode;
+    protected String floorCancelMode;
+    protected boolean floorCancelWhileMoving;
 
     private static final String KEY_LIFT_ID = "lift_id";
     private static final String KEY_SPEED = "speed";
@@ -29,6 +32,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     private static final String KEY_LEVELLING_DISTANCE = "levelling_distance";
     private static final String KEY_LEVELLING_SPEED = "levelling_speed";
     private static final String KEY_DOOR_HOLD_ENABLED = "door_hold_enabled";
+    private static final String KEY_DOOR_BUTTON_LIGHT_MODE = "door_button_light_mode";
+    private static final String KEY_FLOOR_CANCEL_MODE = "floor_cancel_mode";
+    private static final String KEY_FLOOR_CANCEL_WHILE_MOVING = "floor_cancel_while_moving";
 
     public static final double DEFAULT_SPEED = 10.0;
     public static final double DEFAULT_ACCELERATION = 4.0;
@@ -47,6 +53,8 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     public static final double MAX_LEVELLING_SPEED = 5;
     public static final double STEP = 0.5;
     public static final String DEFAULT_MOTION_PROFILE = "STANDARD";
+    public static final String DEFAULT_DOOR_BUTTON_LIGHT_MODE = "MOMENTARY";
+    public static final String DEFAULT_FLOOR_CANCEL_MODE = "DOUBLE_CLICK";
 
     protected YteLiftConfigSchema(long liftId, double speed, double acceleration, double adoDistance, double levellingDistance, double levellingSpeed) {
         this(liftId, speed, speed, acceleration, acceleration, true, adoDistance, levellingDistance, levellingSpeed,
@@ -69,6 +77,15 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             String motionProfile, boolean doorHoldEnabled) {
+        this(liftId, speed, downSpeed, acceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                DEFAULT_DOOR_BUTTON_LIGHT_MODE, DEFAULT_FLOOR_CANCEL_MODE, false);
+    }
+
+    protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            String motionProfile, boolean doorHoldEnabled, String doorButtonLightMode, String floorCancelMode,
+            boolean floorCancelWhileMoving) {
         this.liftId = liftId;
         this.speed = speed;
         this.acceleration = acceleration;
@@ -80,6 +97,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         this.levellingDistance = levellingDistance;
         this.levellingSpeed = levellingSpeed;
         this.doorHoldEnabled = doorHoldEnabled;
+        this.doorButtonLightMode = doorButtonLightMode;
+        this.floorCancelMode = floorCancelMode;
+        this.floorCancelWhileMoving = floorCancelWhileMoving;
     }
 
     protected YteLiftConfigSchema(ReaderBase readerBase) {
@@ -93,6 +113,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         levellingDistance = DEFAULT_LEVELLING_DISTANCE;
         levellingSpeed = DEFAULT_LEVELLING_SPEED;
         doorHoldEnabled = false;
+        doorButtonLightMode = DEFAULT_DOOR_BUTTON_LIGHT_MODE;
+        floorCancelMode = DEFAULT_FLOOR_CANCEL_MODE;
+        floorCancelWhileMoving = false;
         updateData(readerBase);
     }
 
@@ -109,6 +132,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         readerBase.unpackDouble(KEY_LEVELLING_DISTANCE, value -> levellingDistance = value);
         readerBase.unpackDouble(KEY_LEVELLING_SPEED, value -> levellingSpeed = value);
         doorHoldEnabled = readerBase.getBoolean(KEY_DOOR_HOLD_ENABLED, false);
+        doorButtonLightMode = readerBase.getString(KEY_DOOR_BUTTON_LIGHT_MODE, DEFAULT_DOOR_BUTTON_LIGHT_MODE);
+        floorCancelMode = readerBase.getString(KEY_FLOOR_CANCEL_MODE, DEFAULT_FLOOR_CANCEL_MODE);
+        floorCancelWhileMoving = readerBase.getBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, false);
     }
 
     @Override
@@ -124,6 +150,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         writerBase.writeDouble(KEY_LEVELLING_DISTANCE, levellingDistance);
         writerBase.writeDouble(KEY_LEVELLING_SPEED, levellingSpeed);
         writerBase.writeBoolean(KEY_DOOR_HOLD_ENABLED, doorHoldEnabled);
+        writerBase.writeString(KEY_DOOR_BUTTON_LIGHT_MODE, doorButtonLightMode);
+        writerBase.writeString(KEY_FLOOR_CANCEL_MODE, floorCancelMode);
+        writerBase.writeBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, floorCancelWhileMoving);
     }
 
     @Override

--- a/fabric/src/main/java/top/xfunny/mixin/MixinLift.java
+++ b/fabric/src/main/java/top/xfunny/mixin/MixinLift.java
@@ -15,6 +15,7 @@ import top.xfunny.mod.Init;
 import top.xfunny.mod.LiftDisplayDirection;
 import top.xfunny.mod.LiftDisplayDirectionState;
 import top.xfunny.mod.LiftDoorControlState;
+import top.xfunny.mod.LiftFloorCancelState;
 import top.xfunny.mod.DisplayDirectionMode;
 import top.xfunny.mod.LiftDisplayState;
 import top.xfunny.mod.LiftMotionProfile;
@@ -98,17 +99,27 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
                 yte$applyDoorCommand(doorCommand);
             }
 
-            if (LiftDoorControlState.isHoldActive(id) && getSpeed() == 0 && yte$isExactlyAtFloor()) {
-                if (LiftDoorControlState.isHoldExpired(id)) {
+            final Integer cancelledFloor = LiftFloorCancelState.consume(id);
+            if (cancelledFloor != null && getSpeed() == 0 && yte$isExactlyAtFloor()
+                    && cancelledFloor >= 0 && cancelledFloor < getFloors().size()) {
+                final boolean instructionRemoved = getInstructions().removeIf(instruction ->
+                        instruction.getFloor() == cancelledFloor && instruction.getDirection() == LiftDirection.NONE);
+                if (instructionRemoved) {
+                    setNeedsUpdate(true);
+                }
+            }
+
+            if (LiftDoorControlState.isHoldActive(id)) {
+                final boolean stoppedAtFloor = getSpeed() == 0 && yte$isExactlyAtFloor();
+                if (!YteLiftConfigStore.isDoorHoldEnabled(id) || LiftDoorControlState.isHoldExpired(id)) {
                     LiftDoorControlState.endHold(id);
+                    Init.sendLiftHoldState(id, false);
                     final float doorValue = ((Lift) (Object) this).getDoorValue();
-                    if (doorValue >= 0.999F) {
+                    if (stoppedAtFloor && doorValue >= 0.999F) {
                         setStoppingCoolDown(YTE_DOOR_CLOSED_DELAY + YTE_SINGLE_DOOR_MOVE_TIME);
                         setNeedsUpdate(true);
                     }
-                } else if (!getInstructions().isEmpty()) {
-                    LiftDoorControlState.endHold(id);
-                } else {
+                } else if (stoppedAtFloor) {
                     final float doorValue = ((Lift) (Object) this).getDoorValue();
                     final long fullOpenCoolDown = YTE_LIFT_STOPPING_TIME - YTE_SINGLE_DOOR_MOVE_TIME;
                     if (doorValue >= 0.999F && getStoppingCoolDown() < fullOpenCoolDown) {
@@ -230,8 +241,10 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
                 && lift.getDoorValue() <= 0;
         boolean openCommandApplied = false;
 
-        if (command == LiftDoorControlState.Command.HOLD_OPEN) {
+        if (command == LiftDoorControlState.Command.HOLD_OPEN
+                && YteLiftConfigStore.isDoorHoldEnabled(id)) {
             LiftDoorControlState.beginHold(id);
+            Init.sendLiftHoldState(id, true);
             final float doorValue = Utilities.clamp(lift.getDoorValue(), 0, 1);
             if (doorValue >= 1) {
                 setStoppingCoolDown(fullOpenCoolDown);
@@ -239,7 +252,7 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
             } else if (doorValue > 0 && coolDown <= closeStartCoolDown) {
                 setStoppingCoolDown(YTE_LIFT_STOPPING_TIME - Math.round(doorValue * YTE_SINGLE_DOOR_MOVE_TIME));
                 openCommandApplied = true;
-            } else if (doorValue <= 0 && coolDown < YTE_DOOR_CLOSED_DELAY) {
+            } else if (doorValue <= 0 && coolDown <= YTE_DOOR_CLOSED_DELAY) {
                 setStoppingCoolDown(YTE_LIFT_STOPPING_TIME);
                 openCommandApplied = true;
             }
@@ -251,12 +264,13 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
             } else if (doorValue > 0 && coolDown <= closeStartCoolDown) {
                 setStoppingCoolDown(YTE_LIFT_STOPPING_TIME - Math.round(doorValue * YTE_SINGLE_DOOR_MOVE_TIME));
                 openCommandApplied = true;
-            } else if (doorValue <= 0 && coolDown < YTE_DOOR_CLOSED_DELAY) {
+            } else if (doorValue <= 0 && coolDown <= YTE_DOOR_CLOSED_DELAY) {
                 setStoppingCoolDown(YTE_LIFT_STOPPING_TIME);
                 openCommandApplied = true;
             }
         } else if (command == LiftDoorControlState.Command.CLOSE) {
             LiftDoorControlState.endHold(id);
+            Init.sendLiftHoldState(id, false);
             if (lift.getDoorValue() >= 0.999F) {
                 setStoppingCoolDown(closeStartCoolDown);
             }

--- a/fabric/src/main/java/top/xfunny/mixin/MixinLiftCustomizationScreen.java
+++ b/fabric/src/main/java/top/xfunny/mixin/MixinLiftCustomizationScreen.java
@@ -27,6 +27,8 @@ import top.xfunny.mod.client.InitClient;
 import top.xfunny.mod.client.YteMinecraftClientData;
 import top.xfunny.mod.config.YteLiftConfigStore;
 import top.xfunny.mod.packet.YtePacketUpdateData;
+import top.xfunny.mod.LiftDoorButtonLightMode;
+import top.xfunny.mod.LiftFloorCancelMode;
 import top.xfunny.mod.LiftMotionProfile;
 
 import java.util.Locale;
@@ -62,6 +64,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique private ButtonWidgetExtension yte$directionLinkButton;
     @Unique private ButtonWidgetExtension yte$motionProfileButton;
     @Unique private ButtonWidgetExtension yte$doorHoldButton;
+    @Unique private ButtonWidgetExtension yte$doorButtonLightModeButton;
+    @Unique private ButtonWidgetExtension yte$floorCancelModeButton;
     @Unique private TextFieldWidgetExtension yte$speedField;
     @Unique private TextFieldWidgetExtension yte$accelerationField;
     @Unique private TextFieldWidgetExtension yte$downSpeedField;
@@ -94,6 +98,10 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique private LiftMotionProfile yte$lastSentMotionProfile = LiftMotionProfile.STANDARD;
     @Unique private boolean yte$doorHoldEnabled;
     @Unique private boolean yte$lastSentDoorHoldEnabled;
+    @Unique private LiftDoorButtonLightMode yte$doorButtonLightMode = LiftDoorButtonLightMode.MOMENTARY;
+    @Unique private LiftDoorButtonLightMode yte$lastSentDoorButtonLightMode = LiftDoorButtonLightMode.MOMENTARY;
+    @Unique private LiftFloorCancelMode yte$floorCancelMode = LiftFloorCancelMode.DOUBLE_CLICK;
+    @Unique private LiftFloorCancelMode yte$lastSentFloorCancelMode = LiftFloorCancelMode.DOUBLE_CLICK;
     @Unique private double yte$lastSentAdoDistance = -1;
     @Unique private double yte$lastSentLevellingDistance = -1;
     @Unique private double yte$lastSentLevellingSpeed = -1;
@@ -108,6 +116,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique private int yte$directionLinkButtonContentY;
     @Unique private int yte$motionProfileButtonContentY;
     @Unique private int yte$doorHoldButtonContentY;
+    @Unique private int yte$doorButtonLightModeButtonContentY;
+    @Unique private int yte$floorCancelModeButtonContentY;
     @Unique private boolean yte$scrollingTextButtonsSuppressed;
 
     @Inject(method = "<init>", at = @At("TAIL"))
@@ -122,6 +132,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$directionParametersLinked = config == null || config.areDirectionParametersLinked();
         yte$motionProfile = config == null ? LiftMotionProfile.STANDARD : config.getMotionProfile();
         yte$doorHoldEnabled = config != null && config.isDoorHoldEnabled();
+        yte$doorButtonLightMode = config == null ? LiftDoorButtonLightMode.MOMENTARY : config.getDoorButtonLightMode();
+        yte$floorCancelMode = config == null ? LiftFloorCancelMode.DOUBLE_CLICK : config.getFloorCancelMode();
         final double currentAdoDistance = config != null ? config.getAdoDistance() : YteLiftConfig.DEFAULT_ADO_DISTANCE;
         final double currentLevellingDistance = config != null ? config.getLevellingDistance() : YteLiftConfig.DEFAULT_LEVELLING_DISTANCE;
         final double currentLevellingSpeed = config != null ? config.getLevellingSpeed() : YteLiftConfig.DEFAULT_LEVELLING_SPEED;
@@ -163,6 +175,10 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 TextHelper.literal(""), button -> yte$toggleMotionProfile());
         yte$doorHoldButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
                 TextHelper.literal(""), button -> yte$toggleDoorHold());
+        yte$doorButtonLightModeButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
+                TextHelper.literal(""), button -> yte$toggleDoorButtonLightMode());
+        yte$floorCancelModeButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
+                TextHelper.literal(""), button -> yte$toggleFloorCancelMode());
 
         yte$speedField = yte$createNumberField(currentSpeed);
         yte$accelerationField = yte$createNumberField(currentAccel);
@@ -182,13 +198,14 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$lastSentLevellingDistance = currentLevellingDistance;
         yte$lastSentLevellingSpeed = currentLevellingSpeed;
         yte$lastSentDoorHoldEnabled = yte$doorHoldEnabled;
+        yte$lastSentDoorButtonLightMode = yte$doorButtonLightMode;
+        yte$lastSentFloorCancelMode = yte$floorCancelMode;
     }
 
     @Inject(method = "init2", at = @At("TAIL"))
     private void onInit2(CallbackInfo ci) {
         // 与原版全宽控件对齐：x=0, width=width2
-        // Speed: row 11 文字, row 12 滑块
-        // Accel: row 13 文字, row 14 滑块
+        // Keep the custom settings and motion controls in one continuous list.
         yte$professionalModeButton.setX2(0);
         yte$professionalModeButton.setY2(IGui.SQUARE_SIZE * 11);
         yte$professionalModeButton.setWidth2(width2);
@@ -201,11 +218,19 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$doorHoldButton.setX2(0);
         yte$doorHoldButton.setY2(IGui.SQUARE_SIZE * 14);
         yte$doorHoldButton.setWidth2(width2);
+        yte$doorButtonLightModeButton.setX2(0);
+        yte$doorButtonLightModeButton.setY2(IGui.SQUARE_SIZE * 15);
+        yte$doorButtonLightModeButton.setWidth2(width2);
+        yte$floorCancelModeButton.setX2(0);
+        yte$floorCancelModeButton.setY2(IGui.SQUARE_SIZE * 16);
+        yte$floorCancelModeButton.setWidth2(width2);
 
         addChild(new ClickableWidget(yte$professionalModeButton));
         addChild(new ClickableWidget(yte$directionLinkButton));
         addChild(new ClickableWidget(yte$motionProfileButton));
         addChild(new ClickableWidget(yte$doorHoldButton));
+        addChild(new ClickableWidget(yte$doorButtonLightModeButton));
+        addChild(new ClickableWidget(yte$floorCancelModeButton));
         addChild(new ClickableWidget(yte$sliderSpeed));
         addChild(new ClickableWidget(yte$sliderAcceleration));
         addChild(new ClickableWidget(yte$sliderDownSpeed));
@@ -235,16 +260,20 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$drawExtendedBackground(graphicsHolder);
         // Long button labels use a screen-space horizontal scissor rectangle.
         // A matrix-only vertical translation moves the button but not that
-        // rectangle, so suppress these two buttons and render them later at a
+        // rectangle, so suppress these text buttons and render them later at a
         // physically adjusted Y coordinate.
         yte$liftStyleButtonContentY = buttonLiftStyle.getY2();
         yte$directionLinkButtonContentY = yte$directionLinkButton.getY2();
         yte$motionProfileButtonContentY = yte$motionProfileButton.getY2();
         yte$doorHoldButtonContentY = yte$doorHoldButton.getY2();
+        yte$doorButtonLightModeButtonContentY = yte$doorButtonLightModeButton.getY2();
+        yte$floorCancelModeButtonContentY = yte$floorCancelModeButton.getY2();
         buttonLiftStyle.setVisibleMapped(false);
         yte$directionLinkButton.setVisibleMapped(false);
         yte$motionProfileButton.setVisibleMapped(false);
         yte$doorHoldButton.setVisibleMapped(false);
+        yte$doorButtonLightModeButton.setVisibleMapped(false);
+        yte$floorCancelModeButton.setVisibleMapped(false);
         yte$scrollingTextButtonsSuppressed = true;
         graphicsHolder.push();
         graphicsHolder.translate(0, -yte$scrollOffset, 0);
@@ -276,8 +305,6 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Inject(method = "render", at = @At("TAIL"))
     private void onRender(GraphicsHolder graphicsHolder, int mouseX, int mouseY, float delta,
             CallbackInfo ci) {
-        // "Speed: X.X m/s" 文字行（滑块上方），左对齐
-        final int labelY1 = IGui.SQUARE_SIZE * 12 + IGui.TEXT_PADDING;
         final double upSpeed = yte$professionalMode
                 ? yte$parseNumber(yte$speedField, yte$lastSentSpeed, YteLiftConfig.MIN_SPEED, YteLiftConfig.MAX_SPEED)
                 : yte$getEasyModeValue(0, yte$sliderSpeed, valueToSpeed(yte$sliderSpeed.getIntValue()));
@@ -301,15 +328,15 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 : yte$getEasyModeValue(6, yte$sliderLevellingSpeed, valueToLevellingSpeed(yte$sliderLevellingSpeed.getIntValue()));
 
         if (yte$directionParametersLinked) {
-            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_speed", "gui.yte.lift_speed_value", upSpeed, 15);
-            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_acceleration", "gui.yte.lift_acceleration_value", upAccel, 17);
+            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_speed", "gui.yte.lift_speed_value", upSpeed, 17);
+            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_acceleration", "gui.yte.lift_acceleration_value", upAccel, 19);
         } else {
-            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_up_speed", "gui.yte.lift_up_speed_value", upSpeed, 15);
-            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_down_speed", "gui.yte.lift_down_speed_value", downSpeed, 17);
-            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_up_acceleration", "gui.yte.lift_up_acceleration_value", upAccel, 19);
-            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_down_acceleration", "gui.yte.lift_down_acceleration_value", downAccel, 21);
+            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_up_speed", "gui.yte.lift_up_speed_value", upSpeed, 17);
+            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_down_speed", "gui.yte.lift_down_speed_value", downSpeed, 19);
+            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_up_acceleration", "gui.yte.lift_up_acceleration_value", upAccel, 21);
+            yte$drawModeLabel(graphicsHolder, "gui.yte.lift_down_acceleration", "gui.yte.lift_down_acceleration_value", downAccel, 23);
         }
-        final int extraStartRow = yte$directionParametersLinked ? 19 : 23;
+        final int extraStartRow = yte$directionParametersLinked ? 21 : 25;
         yte$drawModeLabel(graphicsHolder, "gui.yte.lift_ado_distance", "gui.yte.lift_ado_distance_value", adoDistance, extraStartRow);
         yte$drawModeLabel(graphicsHolder, "gui.yte.lift_levelling_distance", "gui.yte.lift_levelling_distance_value", levellingDistance, extraStartRow + 2);
         yte$drawModeLabel(graphicsHolder, "gui.yte.lift_levelling_speed", "gui.yte.lift_levelling_speed_value", levellingSpeed, extraStartRow + 4);
@@ -320,7 +347,9 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 || yte$motionProfile != yte$lastSentMotionProfile
                 || adoDistance != yte$lastSentAdoDistance || levellingDistance != yte$lastSentLevellingDistance
                 || levellingSpeed != yte$lastSentLevellingSpeed
-                || yte$doorHoldEnabled != yte$lastSentDoorHoldEnabled) {
+                || yte$doorHoldEnabled != yte$lastSentDoorHoldEnabled
+                || yte$doorButtonLightMode != yte$lastSentDoorButtonLightMode
+                || yte$floorCancelMode != yte$lastSentFloorCancelMode) {
             yte$lastSentSpeed = upSpeed;
             yte$lastSentDownSpeed = downSpeed;
             yte$lastSentAccel = upAccel;
@@ -331,13 +360,16 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
             yte$lastSentLevellingDistance = levellingDistance;
             yte$lastSentLevellingSpeed = levellingSpeed;
             yte$lastSentDoorHoldEnabled = yte$doorHoldEnabled;
+            yte$lastSentDoorButtonLightMode = yte$doorButtonLightMode;
+            yte$lastSentFloorCancelMode = yte$floorCancelMode;
 
             final long liftId = lift.getId();
             final YteLiftConfig config = new YteLiftConfig(liftId, upSpeed, downSpeed, upAccel, downAccel,
                     yte$directionParametersLinked, adoDistance, levellingDistance, levellingSpeed, yte$motionProfile,
-                    yte$doorHoldEnabled);
+                    yte$doorHoldEnabled, yte$doorButtonLightMode, yte$floorCancelMode, false);
             YteLiftConfigStore.put(liftId, upSpeed, downSpeed, upAccel, downAccel,
-                    adoDistance, levellingDistance, levellingSpeed, yte$motionProfile, yte$doorHoldEnabled);
+                    adoDistance, levellingDistance, levellingSpeed, yte$motionProfile, yte$doorHoldEnabled,
+                    yte$doorButtonLightMode, yte$floorCancelMode, false);
 
             final YteUpdateDataRequest request = new YteUpdateDataRequest(
                     config, YteMinecraftClientData.getInstance());
@@ -359,6 +391,10 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                     mouseX, screenMouseY, delta);
             yte$renderScrollSafeButton(graphicsHolder, yte$doorHoldButton, yte$doorHoldButtonContentY,
                     mouseX, screenMouseY, delta);
+            yte$renderScrollSafeButton(graphicsHolder, yte$doorButtonLightModeButton,
+                    yte$doorButtonLightModeButtonContentY, mouseX, screenMouseY, delta);
+            yte$renderScrollSafeButton(graphicsHolder, yte$floorCancelModeButton,
+                    yte$floorCancelModeButtonContentY, mouseX, screenMouseY, delta);
             yte$scrollingTextButtonsSuppressed = false;
         }
         yte$drawScrollbar(graphicsHolder);
@@ -442,22 +478,22 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
 
     @Unique
     private void yte$layoutDirectionWidgets() {
-        yte$positionSlider(yte$sliderSpeed, 16);
-        yte$positionField(yte$speedField, 16);
+        yte$positionSlider(yte$sliderSpeed, 18);
+        yte$positionField(yte$speedField, 18);
 
         if (yte$directionParametersLinked) {
-            yte$positionSlider(yte$sliderAcceleration, 18);
-            yte$positionField(yte$accelerationField, 18);
-        } else {
-            yte$positionSlider(yte$sliderDownSpeed, 18);
-            yte$positionField(yte$downSpeedField, 18);
             yte$positionSlider(yte$sliderAcceleration, 20);
             yte$positionField(yte$accelerationField, 20);
-            yte$positionSlider(yte$sliderDownAcceleration, 22);
-            yte$positionField(yte$downAccelerationField, 22);
+        } else {
+            yte$positionSlider(yte$sliderDownSpeed, 20);
+            yte$positionField(yte$downSpeedField, 20);
+            yte$positionSlider(yte$sliderAcceleration, 22);
+            yte$positionField(yte$accelerationField, 22);
+            yte$positionSlider(yte$sliderDownAcceleration, 24);
+            yte$positionField(yte$downAccelerationField, 24);
         }
 
-        final int extraControlRow = yte$directionParametersLinked ? 20 : 24;
+        final int extraControlRow = yte$directionParametersLinked ? 22 : 26;
         yte$positionSlider(yte$sliderAdoDistance, extraControlRow);
         yte$positionField(yte$adoDistanceField, extraControlRow);
         yte$positionSlider(yte$sliderLevellingDistance, extraControlRow + 2);
@@ -501,6 +537,18 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique
     private void yte$toggleDoorHold() {
         yte$doorHoldEnabled = !yte$doorHoldEnabled;
+        yte$updateModeWidgets();
+    }
+
+    @Unique
+    private void yte$toggleDoorButtonLightMode() {
+        yte$doorButtonLightMode = yte$doorButtonLightMode.nextSelectable();
+        yte$updateModeWidgets();
+    }
+
+    @Unique
+    private void yte$toggleFloorCancelMode() {
+        yte$floorCancelMode = yte$floorCancelMode.next();
         yte$updateModeWidgets();
     }
 
@@ -614,6 +662,10 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$doorHoldButton.setMessage2(new Text(TextHelper.translatable(yte$doorHoldEnabled
                 ? "gui.yte.lift_door_hold_on"
                 : "gui.yte.lift_door_hold_off").data));
+        yte$doorButtonLightModeButton.setMessage2(new Text(TextHelper.translatable(
+                yte$doorButtonLightMode.getTranslationKey()).data));
+        yte$floorCancelModeButton.setMessage2(new Text(TextHelper.translatable(
+                yte$floorCancelMode.getTranslationKey()).data));
     }
 
     @Unique
@@ -678,7 +730,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
 
     @Unique
     private int yte$getContentRows() {
-        return yte$directionParametersLinked ? 25 : 29;
+        return yte$directionParametersLinked ? 27 : 31;
     }
 
     @Unique

--- a/fabric/src/main/java/top/xfunny/mixin/MixinLiftSelectionScreen.java
+++ b/fabric/src/main/java/top/xfunny/mixin/MixinLiftSelectionScreen.java
@@ -7,7 +7,6 @@ import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.mtr.mapping.holder.BlockPos;
 import org.mtr.mapping.holder.ClickableWidget;
 import org.mtr.mapping.holder.World;
-import org.mtr.mapping.mapper.ButtonWidgetExtension;
 import org.mtr.mapping.mapper.TextHelper;
 import org.mtr.mod.client.MinecraftClientData;
 import org.mtr.mod.data.IGui;
@@ -23,11 +22,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import top.xfunny.mod.LiftDoorButtonLightMode;
 import top.xfunny.mod.LiftDoorControlState;
 import top.xfunny.mod.LiftDisplayDirectionState;
+import top.xfunny.mod.LiftFloorCancelMode;
 import top.xfunny.mod.client.InitClient;
+import top.xfunny.mod.client.screen.widget.LiftSelectionButtonWidget;
 import top.xfunny.mod.config.YteLiftConfigStore;
 import top.xfunny.mod.packet.PacketLiftDoorControl;
+import top.xfunny.mod.packet.PacketLiftFloorCancel;
+import top.xfunny.mod.packet.PacketLiftHoldState;
 import top.xfunny.mod.util.GetLiftDetails;
 
 @Mixin(value = LiftSelectionScreen.class, remap = false)
@@ -37,11 +41,27 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
     @Shadow @Final private ObjectArrayList<BlockPos> floorLevels;
     @Shadow @Final private long liftId;
 
-    @Unique private ButtonWidgetExtension yte$holdOpenButton;
-    @Unique private ButtonWidgetExtension yte$openDoorButton;
-    @Unique private ButtonWidgetExtension yte$closeDoorButton;
+    @Unique private static final long YTE_DOUBLE_CLICK_WINDOW = 400;
+    @Unique private static final long YTE_LONG_PRESS_TIME = 750;
+    @Unique private static final long YTE_DOOR_REPEAT_INTERVAL = 250;
+    @Unique private static final long YTE_TIMED_LIGHT_DURATION = 1000;
+
+    @Unique private LiftSelectionButtonWidget yte$holdOpenButton;
+    @Unique private LiftSelectionButtonWidget yte$openDoorButton;
+    @Unique private LiftSelectionButtonWidget yte$closeDoorButton;
     @Unique private boolean yte$clearDoorButtonFocus;
     @Unique private boolean yte$lastHoldEnabled;
+    @Unique private LiftDoorControlState.Command yte$pressedDoorCommand;
+    @Unique private long yte$nextDoorRepeatTime;
+    @Unique private long yte$holdOpenLightUntil;
+    @Unique private long yte$openDoorLightUntil;
+    @Unique private long yte$closeDoorLightUntil;
+    @Unique private int yte$lastFloorClickIndex = -1;
+    @Unique private long yte$lastFloorClickTime;
+    @Unique private boolean yte$lastFloorClickWasSelected;
+    @Unique private int yte$heldFloorIndex = -1;
+    @Unique private long yte$floorHoldStartTime;
+    @Unique private boolean yte$floorHoldArmed;
 
     @Redirect(
             method = "lambda$new$0",
@@ -57,16 +77,16 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void yte$createDoorButtons(long liftId, CallbackInfo ci) {
-        yte$holdOpenButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
+        yte$holdOpenButton = new LiftSelectionButtonWidget(0, 0, 0, IGui.SQUARE_SIZE,
                 TextHelper.translatable("gui.yte.lift_hold_open"), button -> yte$sendDoorCommand(LiftDoorControlState.Command.HOLD_OPEN));
-        yte$openDoorButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
+        yte$openDoorButton = new LiftSelectionButtonWidget(0, 0, 0, IGui.SQUARE_SIZE,
                 TextHelper.literal("◀▶"), button -> yte$sendDoorCommand(LiftDoorControlState.Command.OPEN));
-        yte$closeDoorButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
+        yte$closeDoorButton = new LiftSelectionButtonWidget(0, 0, 0, IGui.SQUARE_SIZE,
                 TextHelper.literal("▶◀"), button -> yte$sendDoorCommand(LiftDoorControlState.Command.CLOSE));
     }
 
-    @Inject(method = "onPress", at = @At("HEAD"))
-    private void yte$resetDirectionForCurrentFloorCarCall(
+    @Inject(method = "onPress", at = @At("HEAD"), cancellable = true)
+    private void yte$handleFloorButtonPress(
             DashboardListItem ignoredItem, int index, CallbackInfo ci) {
         final Lift lift = MinecraftClientData.getLift(liftId);
         if (lift == null || index < 0 || index >= floorLevels.size()) {
@@ -76,6 +96,27 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
         final MixinLiftSchema schema = (MixinLiftSchema) lift;
         final int selectedFloor = lift.getFloorIndex(org.mtr.mod.Init.blockPosToPosition(
                 floorLevels.get(floorLevels.size() - index - 1)));
+        final boolean selected = lift.hasInstruction(selectedFloor).contains(LiftDirection.NONE);
+        final long currentTime = System.currentTimeMillis();
+        final LiftFloorCancelMode cancelMode = YteLiftConfigStore.getFloorCancelMode(liftId);
+
+        if (cancelMode == LiftFloorCancelMode.DOUBLE_CLICK) {
+            if (selected && yte$lastFloorClickWasSelected && yte$lastFloorClickIndex == index
+                    && currentTime - yte$lastFloorClickTime <= YTE_DOUBLE_CLICK_WINDOW) {
+                yte$sendFloorCancellation(selectedFloor);
+                yte$resetFloorClickTracking();
+                ci.cancel();
+                return;
+            }
+            yte$lastFloorClickIndex = index;
+            yte$lastFloorClickTime = currentTime;
+            yte$lastFloorClickWasSelected = selected;
+        } else if (selected) {
+            yte$heldFloorIndex = index;
+            yte$floorHoldStartTime = currentTime;
+            yte$floorHoldArmed = true;
+        }
+
         final int currentFloor = lift.getFloorIndex(lift.getCurrentFloor().getPosition());
         if (selectedFloor == currentFloor
                 && schema.getSpeed() == 0
@@ -84,6 +125,13 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
                 && lift.getDoorValue() == 0) {
             LiftDisplayDirectionState.get(liftId).resetForCarSameFloorOpen();
         }
+    }
+
+    @Redirect(
+            method = "onPress",
+            at = @At(value = "INVOKE", target = "Lorg/mtr/mod/screen/LiftSelectionScreen;onClose2()V")
+    )
+    private void yte$keepSelectionScreenOpen(LiftSelectionScreen ignoredScreen) {
     }
 
     @Inject(method = "init2", at = @At("TAIL"))
@@ -97,6 +145,7 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
 
         yte$lastHoldEnabled = YteLiftConfigStore.isDoorHoldEnabled(liftId);
         yte$updateDoorButtonLayout(buttonY);
+        InitClient.REGISTRY_CLIENT.sendPacketToServer(PacketLiftHoldState.query(liftId));
     }
 
     @Inject(method = "tick2", at = @At("TAIL"))
@@ -113,24 +162,31 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
         }
 
         final Lift lift = MinecraftClientData.getLift(liftId);
-        final boolean stoppedAtFloor = lift != null && yte$isStoppedAtFloor(lift);
-        yte$holdOpenButton.active = stoppedAtFloor;
-        yte$openDoorButton.active = stoppedAtFloor;
+        yte$holdOpenButton.setActiveMapped(true);
+        yte$openDoorButton.setActiveMapped(true);
+        yte$closeDoorButton.setActiveMapped(true);
 
-        if (!stoppedAtFloor) {
-            yte$closeDoorButton.active = false;
-            return;
+        final long currentTime = System.currentTimeMillis();
+        if (yte$pressedDoorCommand != null) {
+            final LiftSelectionButtonWidget pressedButton = yte$getDoorButton(yte$pressedDoorCommand);
+            if (pressedButton == null || !pressedButton.getVisibleMapped()) {
+                yte$finishDoorButtonPress(currentTime);
+            } else if (yte$pressedDoorCommand != LiftDoorControlState.Command.HOLD_OPEN
+                    && currentTime >= yte$nextDoorRepeatTime) {
+                yte$sendDoorCommand(yte$pressedDoorCommand);
+                yte$nextDoorRepeatTime = currentTime + YTE_DOOR_REPEAT_INTERVAL;
+            }
         }
 
-        final long coolDown = ((MixinLiftSchema) lift).getStoppingCoolDown();
-        final boolean doorFullyOpen = lift.getDoorValue() >= 0.999F;
-        if (holdEnabled && doorFullyOpen) {
-            yte$closeDoorButton.active = coolDown > yte$closeStartCoolDown();
-        } else {
-            yte$closeDoorButton.active = doorFullyOpen
-                    && coolDown <= yte$fullOpenCoolDown() - 300
-                    && coolDown > yte$closeStartCoolDown();
+        if (yte$floorHoldArmed) {
+            if (selectionList.getHoverItemIndex() != yte$heldFloorIndex) {
+                yte$resetFloorHold();
+            } else if (currentTime - yte$floorHoldStartTime >= YTE_LONG_PRESS_TIME) {
+                yte$cancelHeldFloorIfAllowed(lift);
+            }
         }
+
+        yte$updateDoorButtonLights(currentTime);
     }
 
     @Unique
@@ -160,8 +216,161 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
         }
     }
 
+    @Override
+    public boolean mouseClicked2(double mouseX, double mouseY, int button) {
+        if (button == 0) {
+            final LiftDoorControlState.Command command = yte$getDoorCommandAt(mouseX, mouseY);
+            if (command != null) {
+                yte$startDoorButtonPress(command);
+                return true;
+            }
+        }
+        return super.mouseClicked2(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseReleased2(double mouseX, double mouseY, int button) {
+        if (button == 0 && yte$pressedDoorCommand != null) {
+            yte$finishDoorButtonPress(System.currentTimeMillis());
+            return true;
+        }
+        final boolean handled = super.mouseReleased2(mouseX, mouseY, button);
+        if (button == 0) {
+            yte$resetFloorHold();
+        }
+        return handled;
+    }
+
+    @Unique
+    private LiftDoorControlState.Command yte$getDoorCommandAt(double mouseX, double mouseY) {
+        if (yte$isClickableDoorButton(yte$holdOpenButton, mouseX, mouseY)) {
+            return LiftDoorControlState.Command.HOLD_OPEN;
+        }
+        if (yte$isClickableDoorButton(yte$openDoorButton, mouseX, mouseY)) {
+            return LiftDoorControlState.Command.OPEN;
+        }
+        if (yte$isClickableDoorButton(yte$closeDoorButton, mouseX, mouseY)) {
+            return LiftDoorControlState.Command.CLOSE;
+        }
+        return null;
+    }
+
+    @Unique
+    private static boolean yte$isClickableDoorButton(LiftSelectionButtonWidget button, double mouseX, double mouseY) {
+        return button.getVisibleMapped() && button.isMouseOver2(mouseX, mouseY);
+    }
+
+    @Unique
+    private void yte$startDoorButtonPress(LiftDoorControlState.Command command) {
+        final long currentTime = System.currentTimeMillis();
+        if (yte$pressedDoorCommand != null) {
+            yte$finishDoorButtonPress(currentTime);
+        }
+        yte$pressedDoorCommand = command;
+        yte$nextDoorRepeatTime = currentTime + YTE_DOOR_REPEAT_INTERVAL;
+        yte$sendDoorCommand(command);
+        yte$updateDoorButtonLights(currentTime);
+    }
+
+    @Unique
+    private void yte$finishDoorButtonPress(long currentTime) {
+        if (yte$pressedDoorCommand == null) {
+            return;
+        }
+        if (YteLiftConfigStore.getDoorButtonLightMode(liftId) == LiftDoorButtonLightMode.TIMED) {
+            yte$setDoorLightUntil(yte$pressedDoorCommand, currentTime + YTE_TIMED_LIGHT_DURATION);
+        }
+        yte$pressedDoorCommand = null;
+        yte$updateDoorButtonLights(currentTime);
+    }
+
+    @Unique
+    private void yte$updateDoorButtonLights(long currentTime) {
+        final LiftDoorButtonLightMode lightMode = YteLiftConfigStore.getDoorButtonLightMode(liftId);
+        yte$holdOpenButton.setLit(LiftDoorControlState.isClientHoldActive(liftId) || lightMode.isLit(
+                yte$pressedDoorCommand == LiftDoorControlState.Command.HOLD_OPEN,
+                currentTime < yte$holdOpenLightUntil, false));
+        yte$openDoorButton.setLit(lightMode.isLit(
+                yte$pressedDoorCommand == LiftDoorControlState.Command.OPEN,
+                currentTime < yte$openDoorLightUntil, false));
+        yte$closeDoorButton.setLit(lightMode.isLit(
+                yte$pressedDoorCommand == LiftDoorControlState.Command.CLOSE,
+                currentTime < yte$closeDoorLightUntil, false));
+    }
+
+    @Unique
+    private void yte$setDoorLightUntil(LiftDoorControlState.Command command, long lightUntil) {
+        switch (command) {
+            case HOLD_OPEN:
+                yte$holdOpenLightUntil = lightUntil;
+                break;
+            case OPEN:
+                yte$openDoorLightUntil = lightUntil;
+                break;
+            case CLOSE:
+                yte$closeDoorLightUntil = lightUntil;
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Unique
+    private LiftSelectionButtonWidget yte$getDoorButton(LiftDoorControlState.Command command) {
+        switch (command) {
+            case HOLD_OPEN:
+                return yte$holdOpenButton;
+            case OPEN:
+                return yte$openDoorButton;
+            case CLOSE:
+                return yte$closeDoorButton;
+            default:
+                return null;
+        }
+    }
+
+    @Unique
+    private void yte$cancelHeldFloorIfAllowed(Lift lift) {
+        if (lift != null && ((MixinLiftSchema) lift).getSpeed() == 0
+                && yte$heldFloorIndex >= 0 && yte$heldFloorIndex < floorLevels.size()) {
+            final int floorIndex = yte$getFloorIndex(lift, yte$heldFloorIndex);
+            if (lift.hasInstruction(floorIndex).contains(LiftDirection.NONE)) {
+                yte$sendFloorCancellation(floorIndex);
+            }
+        }
+        yte$resetFloorHold();
+    }
+
+    @Unique
+    private int yte$getFloorIndex(Lift lift, int selectionIndex) {
+        return lift.getFloorIndex(org.mtr.mod.Init.blockPosToPosition(
+                floorLevels.get(floorLevels.size() - selectionIndex - 1)));
+    }
+
+    @Unique
+    private void yte$sendFloorCancellation(int floorIndex) {
+        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLiftFloorCancel(liftId, floorIndex));
+    }
+
+    @Unique
+    private void yte$resetFloorClickTracking() {
+        yte$lastFloorClickIndex = -1;
+        yte$lastFloorClickTime = 0;
+        yte$lastFloorClickWasSelected = false;
+    }
+
+    @Unique
+    private void yte$resetFloorHold() {
+        yte$heldFloorIndex = -1;
+        yte$floorHoldStartTime = 0;
+        yte$floorHoldArmed = false;
+    }
+
     @Unique
     private void yte$sendDoorCommand(LiftDoorControlState.Command command) {
+        if (command == LiftDoorControlState.Command.CLOSE) {
+            yte$holdOpenLightUntil = 0;
+        }
         if (command == LiftDoorControlState.Command.OPEN || command == LiftDoorControlState.Command.HOLD_OPEN) {
             yte$applyClientOpenCommand();
         }
@@ -195,7 +404,7 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
             // waiting for the server round trip causes a visible forward jump.
             schema.setStoppingCoolDown(stoppingTime - Math.round(doorValue * singleDoorMoveTime));
             LiftDoorControlState.beginClientOpenPrediction(liftId, doorValue);
-        } else if (doorValue <= 0 && coolDown < 500) {
+        } else if (doorValue <= 0 && coolDown <= 500) {
             schema.setStoppingCoolDown(stoppingTime);
             LiftDoorControlState.beginClientOpenPrediction(liftId, doorValue);
             if (schema.getInstructions().isEmpty()) {
@@ -218,13 +427,4 @@ public abstract class MixinLiftSelectionScreen extends MTRScreenBase {
         return false;
     }
 
-    @Unique
-    private static long yte$fullOpenCoolDown() {
-        return 2500 + org.mtr.core.data.Vehicle.DOOR_MOVE_TIME / 2;
-    }
-
-    @Unique
-    private static long yte$closeStartCoolDown() {
-        return 500 + org.mtr.core.data.Vehicle.DOOR_MOVE_TIME / 2;
-    }
 }

--- a/fabric/src/main/java/top/xfunny/mod/Init.java
+++ b/fabric/src/main/java/top/xfunny/mod/Init.java
@@ -78,6 +78,8 @@ public final class Init implements Utilities {
             REGISTRY.registerPacket(YtePacketUpdateData.class, YtePacketUpdateData::new);
             REGISTRY.registerPacket(PacketLiftAdoStart.class, PacketLiftAdoStart::new);
             REGISTRY.registerPacket(PacketLiftDoorControl.class, PacketLiftDoorControl::new);
+            REGISTRY.registerPacket(PacketLiftHoldState.class, PacketLiftHoldState::new);
+            REGISTRY.registerPacket(PacketLiftFloorCancel.class, PacketLiftFloorCancel::new);
         });
 
         int currentStep = 1;
@@ -141,6 +143,15 @@ public final class Init implements Utilities {
                     REGISTRY.sendPacketToClient(player,
                             new PacketLiftDoorControl(liftId, top.xfunny.mod.LiftDoorControlState.Command.OPEN,
                                     stoppingCoolDown, resetIdleDirection)));
+        }
+    }
+
+    public static void sendLiftHoldState(long liftId, boolean active) {
+        if (minecraftServer != null) {
+            final long remainingMillis = active ? LiftDoorControlState.getHoldRemainingMillis(liftId) : 0;
+            MinecraftServerHelper.iteratePlayers(minecraftServer, player ->
+                    REGISTRY.sendPacketToClient(player,
+                            PacketLiftHoldState.update(liftId, active && remainingMillis > 0, remainingMillis)));
         }
     }
 

--- a/fabric/src/main/java/top/xfunny/mod/LiftDoorButtonLightMode.java
+++ b/fabric/src/main/java/top/xfunny/mod/LiftDoorButtonLightMode.java
@@ -1,0 +1,48 @@
+package top.xfunny.mod;
+
+public enum LiftDoorButtonLightMode {
+    MOMENTARY("gui.yte.lift_door_button_light_momentary", true),
+    TIMED("gui.yte.lift_door_button_light_timed", true),
+    AUTOMATIC("gui.yte.lift_door_button_light_automatic", false);
+
+    private final String translationKey;
+    private final boolean selectable;
+
+    LiftDoorButtonLightMode(String translationKey, boolean selectable) {
+        this.translationKey = translationKey;
+        this.selectable = selectable;
+    }
+
+    public String getTranslationKey() {
+        return translationKey;
+    }
+
+    public LiftDoorButtonLightMode nextSelectable() {
+        LiftDoorButtonLightMode nextMode = this;
+        do {
+            nextMode = values()[(nextMode.ordinal() + 1) % values().length];
+        } while (!nextMode.selectable);
+        return nextMode;
+    }
+
+    public boolean isLit(boolean pressed, boolean timedLightActive, boolean automaticLightActive) {
+        switch (this) {
+            case MOMENTARY:
+                return pressed;
+            case TIMED:
+                return pressed || timedLightActive;
+            case AUTOMATIC:
+                return automaticLightActive;
+            default:
+                return false;
+        }
+    }
+
+    public static LiftDoorButtonLightMode fromSerializedName(String value) {
+        try {
+            return value == null ? MOMENTARY : valueOf(value);
+        } catch (IllegalArgumentException ignored) {
+            return MOMENTARY;
+        }
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/LiftDoorControlState.java
+++ b/fabric/src/main/java/top/xfunny/mod/LiftDoorControlState.java
@@ -19,6 +19,7 @@ public final class LiftDoorControlState {
     private static final Map<Long, ClientOpenPrediction> CLIENT_OPEN_PREDICTIONS = new ConcurrentHashMap<>();
     private static final Set<Long> ACTIVE_HOLDS = ConcurrentHashMap.newKeySet();
     private static final Map<Long, Long> HOLD_START_TIMES = new ConcurrentHashMap<>();
+    private static final Map<Long, Long> CLIENT_HOLD_EXPIRATION_TIMES = new ConcurrentHashMap<>();
 
     private LiftDoorControlState() {
     }
@@ -48,6 +49,37 @@ public final class LiftDoorControlState {
     public static boolean isHoldExpired(long liftId) {
         final Long startTime = HOLD_START_TIMES.get(liftId);
         return startTime != null && System.currentTimeMillis() - startTime >= HOLD_TIMEOUT;
+    }
+
+    public static long getHoldRemainingMillis(long liftId) {
+        final Long startTime = HOLD_START_TIMES.get(liftId);
+        return startTime == null ? 0 : Math.max(HOLD_TIMEOUT - (System.currentTimeMillis() - startTime), 0);
+    }
+
+    public static void updateClientHold(long liftId, boolean active, long remainingMillis) {
+        if (active && remainingMillis > 0) {
+            CLIENT_HOLD_EXPIRATION_TIMES.put(liftId,
+                    System.currentTimeMillis() + Math.min(remainingMillis, HOLD_TIMEOUT));
+        } else {
+            CLIENT_HOLD_EXPIRATION_TIMES.remove(liftId);
+        }
+    }
+
+    public static boolean isClientHoldActive(long liftId) {
+        final Long expirationTime = CLIENT_HOLD_EXPIRATION_TIMES.get(liftId);
+        if (expirationTime == null) {
+            return false;
+        }
+        if (System.currentTimeMillis() >= expirationTime) {
+            CLIENT_HOLD_EXPIRATION_TIMES.remove(liftId, expirationTime);
+            return false;
+        }
+        return true;
+    }
+
+    public static void clearClientState() {
+        CLIENT_OPEN_PREDICTIONS.clear();
+        CLIENT_HOLD_EXPIRATION_TIMES.clear();
     }
 
     public static void beginClientOpenPrediction(long liftId, float doorValue) {

--- a/fabric/src/main/java/top/xfunny/mod/LiftFloorCancelMode.java
+++ b/fabric/src/main/java/top/xfunny/mod/LiftFloorCancelMode.java
@@ -1,0 +1,29 @@
+package top.xfunny.mod;
+
+public enum LiftFloorCancelMode {
+    DOUBLE_CLICK("gui.yte.lift_floor_cancel_double_click"),
+    LONG_PRESS("gui.yte.lift_floor_cancel_long_press");
+
+    private final String translationKey;
+
+    LiftFloorCancelMode(String translationKey) {
+        this.translationKey = translationKey;
+    }
+
+    public String getTranslationKey() {
+        return translationKey;
+    }
+
+    public LiftFloorCancelMode next() {
+        final LiftFloorCancelMode[] values = values();
+        return values[(ordinal() + 1) % values.length];
+    }
+
+    public static LiftFloorCancelMode fromSerializedName(String value) {
+        try {
+            return value == null ? DOUBLE_CLICK : valueOf(value);
+        } catch (IllegalArgumentException ignored) {
+            return DOUBLE_CLICK;
+        }
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/LiftFloorCancelState.java
+++ b/fabric/src/main/java/top/xfunny/mod/LiftFloorCancelState.java
@@ -1,0 +1,20 @@
+package top.xfunny.mod;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class LiftFloorCancelState {
+
+    private static final Map<Long, Integer> PENDING_CANCELLATIONS = new ConcurrentHashMap<>();
+
+    private LiftFloorCancelState() {
+    }
+
+    public static void request(long liftId, int floorIndex) {
+        PENDING_CANCELLATIONS.put(liftId, floorIndex);
+    }
+
+    public static Integer consume(long liftId) {
+        return PENDING_CANCELLATIONS.remove(liftId);
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/client/InitClient.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/InitClient.java
@@ -9,6 +9,7 @@ import top.xfunny.mod.BlockEntityTypes;
 import top.xfunny.mod.Blocks;
 import top.xfunny.mod.Init;
 import top.xfunny.mod.Items;
+import top.xfunny.mod.LiftDoorControlState;
 import top.xfunny.mod.client.render.*;
 import top.xfunny.mod.client.resource.FontList;
 import top.xfunny.mod.client.sound.SoundPlaybackManager;
@@ -28,6 +29,7 @@ public final class InitClient {
         // 重置 YTE 客户端数据
         YteMinecraftClientData.reset();
         YteLiftConfigStore.clear();
+        LiftDoorControlState.clearClientState();
 
         initializeConfig();
 
@@ -400,6 +402,7 @@ public final class InitClient {
             MinecraftClientData.reset();
             YteMinecraftClientData.reset();
             YteLiftConfigStore.clear();
+            LiftDoorControlState.clearClientState();
             lastMillis = System.currentTimeMillis();
             gameMillis = 0;
 

--- a/fabric/src/main/java/top/xfunny/mod/client/screen/widget/LiftSelectionButtonWidget.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/screen/widget/LiftSelectionButtonWidget.java
@@ -1,0 +1,49 @@
+package top.xfunny.mod.client.screen.widget;
+
+import org.mtr.mapping.holder.MutableText;
+import org.mtr.mapping.mapper.ButtonWidgetExtension;
+import org.mtr.mapping.mapper.GraphicsHolder;
+import org.mtr.mapping.mapper.GuiDrawing;
+import org.mtr.mod.data.IGui;
+
+public final class LiftSelectionButtonWidget extends ButtonWidgetExtension {
+
+    private boolean lit;
+
+    public LiftSelectionButtonWidget(int x, int y, int width, int height, MutableText message,
+            org.mtr.mapping.holder.PressAction pressAction) {
+        super(x, y, width, height, message, pressAction);
+    }
+
+    public void setLit(boolean lit) {
+        this.lit = lit;
+    }
+
+    @Override
+    public void render(GraphicsHolder graphicsHolder, int mouseX, int mouseY, float delta) {
+        if (!getVisibleMapped()) {
+            return;
+        }
+
+        final boolean active = getActiveMapped();
+        final int x = getX2();
+        final int y = getY2();
+        final GuiDrawing guiDrawing = new GuiDrawing(graphicsHolder);
+        guiDrawing.beginDrawingRectangle();
+        guiDrawing.drawRectangle(x + 6, y + 6, x + 14, y + 14,
+                lit ? 0xFFFF0000 : active ? 0xFF000000 : 0xFF444444);
+        guiDrawing.finishDrawingRectangle();
+
+        final String text = getMessage2().getString();
+        final int textWidth = GraphicsHolder.getTextWidth(text);
+        final int availableWidth = Math.max(getWidth2() - 26, 1);
+        graphicsHolder.push();
+        graphicsHolder.translate(x + 20, 0, 0);
+        if (textWidth > availableWidth) {
+            graphicsHolder.scale((float) availableWidth / textWidth, 1, 1);
+        }
+        graphicsHolder.drawText(text, 0, y + IGui.TEXT_PADDING,
+                active ? IGui.ARGB_WHITE : 0xFF777777, false, GraphicsHolder.getDefaultLight());
+        graphicsHolder.pop();
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/config/YteLiftConfigStore.java
+++ b/fabric/src/main/java/top/xfunny/mod/config/YteLiftConfigStore.java
@@ -1,5 +1,7 @@
 package top.xfunny.mod.config;
 
+import top.xfunny.mod.LiftDoorButtonLightMode;
+import top.xfunny.mod.LiftFloorCancelMode;
 import top.xfunny.mod.LiftMotionProfile;
 
 import java.util.Map;
@@ -20,6 +22,9 @@ public final class YteLiftConfigStore {
     private static final Map<Long, Double> levellingSpeedMap = new ConcurrentHashMap<>();
     private static final Map<Long, LiftMotionProfile> motionProfileMap = new ConcurrentHashMap<>();
     private static final Map<Long, Boolean> doorHoldEnabledMap = new ConcurrentHashMap<>();
+    private static final Map<Long, LiftDoorButtonLightMode> doorButtonLightModeMap = new ConcurrentHashMap<>();
+    private static final Map<Long, LiftFloorCancelMode> floorCancelModeMap = new ConcurrentHashMap<>();
+    private static final Map<Long, Boolean> floorCancelWhileMovingMap = new ConcurrentHashMap<>();
 
     private static final double DEFAULT_SPEED = 10.0;
     private static final double DEFAULT_ACCELERATION = 4.0;
@@ -48,6 +53,15 @@ public final class YteLiftConfigStore {
     public static void put(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
             double adoDistance, double levellingDistance, double levellingSpeed, LiftMotionProfile motionProfile,
             boolean doorHoldEnabled) {
+        put(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, adoDistance, levellingDistance,
+                levellingSpeed, motionProfile, doorHoldEnabled, LiftDoorButtonLightMode.MOMENTARY,
+                LiftFloorCancelMode.DOUBLE_CLICK, false);
+    }
+
+    public static void put(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
+            double adoDistance, double levellingDistance, double levellingSpeed, LiftMotionProfile motionProfile,
+            boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode, LiftFloorCancelMode floorCancelMode,
+            boolean floorCancelWhileMoving) {
         speedMap.put(liftId, upSpeed);
         downSpeedMap.put(liftId, downSpeed);
         accelerationMap.put(liftId, upAcceleration);
@@ -57,6 +71,9 @@ public final class YteLiftConfigStore {
         levellingSpeedMap.put(liftId, levellingSpeed);
         motionProfileMap.put(liftId, motionProfile);
         doorHoldEnabledMap.put(liftId, doorHoldEnabled);
+        doorButtonLightModeMap.put(liftId, doorButtonLightMode);
+        floorCancelModeMap.put(liftId, floorCancelMode);
+        floorCancelWhileMovingMap.put(liftId, floorCancelWhileMoving);
     }
 
     public static double getSpeed(long liftId) {
@@ -89,6 +106,18 @@ public final class YteLiftConfigStore {
         return doorHoldEnabledMap.getOrDefault(liftId, false);
     }
 
+    public static LiftDoorButtonLightMode getDoorButtonLightMode(long liftId) {
+        return doorButtonLightModeMap.getOrDefault(liftId, LiftDoorButtonLightMode.MOMENTARY);
+    }
+
+    public static LiftFloorCancelMode getFloorCancelMode(long liftId) {
+        return floorCancelModeMap.getOrDefault(liftId, LiftFloorCancelMode.DOUBLE_CLICK);
+    }
+
+    public static boolean isFloorCancelWhileMovingAllowed(long liftId) {
+        return floorCancelWhileMovingMap.getOrDefault(liftId, false);
+    }
+
     public static void remove(long liftId) {
         speedMap.remove(liftId);
         accelerationMap.remove(liftId);
@@ -99,6 +128,9 @@ public final class YteLiftConfigStore {
         levellingSpeedMap.remove(liftId);
         motionProfileMap.remove(liftId);
         doorHoldEnabledMap.remove(liftId);
+        doorButtonLightModeMap.remove(liftId);
+        floorCancelModeMap.remove(liftId);
+        floorCancelWhileMovingMap.remove(liftId);
     }
 
     public static void clear() {
@@ -111,5 +143,8 @@ public final class YteLiftConfigStore {
         levellingSpeedMap.clear();
         motionProfileMap.clear();
         doorHoldEnabledMap.clear();
+        doorButtonLightModeMap.clear();
+        floorCancelModeMap.clear();
+        floorCancelWhileMovingMap.clear();
     }
 }

--- a/fabric/src/main/java/top/xfunny/mod/packet/PacketLiftFloorCancel.java
+++ b/fabric/src/main/java/top/xfunny/mod/packet/PacketLiftFloorCancel.java
@@ -1,0 +1,35 @@
+package top.xfunny.mod.packet;
+
+import org.mtr.mapping.holder.MinecraftServer;
+import org.mtr.mapping.holder.ServerPlayerEntity;
+import org.mtr.mapping.registry.PacketHandler;
+import org.mtr.mapping.tool.PacketBufferReceiver;
+import org.mtr.mapping.tool.PacketBufferSender;
+import top.xfunny.mod.LiftFloorCancelState;
+
+public final class PacketLiftFloorCancel extends PacketHandler {
+
+    private final long liftId;
+    private final int floorIndex;
+
+    public PacketLiftFloorCancel(PacketBufferReceiver packetBufferReceiver) {
+        liftId = packetBufferReceiver.readLong();
+        floorIndex = packetBufferReceiver.readInt();
+    }
+
+    public PacketLiftFloorCancel(long liftId, int floorIndex) {
+        this.liftId = liftId;
+        this.floorIndex = floorIndex;
+    }
+
+    @Override
+    public void write(PacketBufferSender packetBufferSender) {
+        packetBufferSender.writeLong(liftId);
+        packetBufferSender.writeInt(floorIndex);
+    }
+
+    @Override
+    public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+        LiftFloorCancelState.request(liftId, floorIndex);
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/packet/PacketLiftHoldState.java
+++ b/fabric/src/main/java/top/xfunny/mod/packet/PacketLiftHoldState.java
@@ -1,0 +1,63 @@
+package top.xfunny.mod.packet;
+
+import org.mtr.mapping.holder.MinecraftServer;
+import org.mtr.mapping.holder.ServerPlayerEntity;
+import org.mtr.mapping.registry.PacketHandler;
+import org.mtr.mapping.tool.PacketBufferReceiver;
+import org.mtr.mapping.tool.PacketBufferSender;
+import top.xfunny.mod.Init;
+import top.xfunny.mod.LiftDoorControlState;
+
+public final class PacketLiftHoldState extends PacketHandler {
+
+    private final long liftId;
+    private final boolean query;
+    private final boolean active;
+    private final long remainingMillis;
+
+    public PacketLiftHoldState(PacketBufferReceiver packetBufferReceiver) {
+        liftId = packetBufferReceiver.readLong();
+        query = packetBufferReceiver.readBoolean();
+        active = packetBufferReceiver.readBoolean();
+        remainingMillis = packetBufferReceiver.readLong();
+    }
+
+    private PacketLiftHoldState(long liftId, boolean query, boolean active, long remainingMillis) {
+        this.liftId = liftId;
+        this.query = query;
+        this.active = active;
+        this.remainingMillis = remainingMillis;
+    }
+
+    public static PacketLiftHoldState query(long liftId) {
+        return new PacketLiftHoldState(liftId, true, false, 0);
+    }
+
+    public static PacketLiftHoldState update(long liftId, boolean active, long remainingMillis) {
+        return new PacketLiftHoldState(liftId, false, active, remainingMillis);
+    }
+
+    @Override
+    public void write(PacketBufferSender packetBufferSender) {
+        packetBufferSender.writeLong(liftId);
+        packetBufferSender.writeBoolean(query);
+        packetBufferSender.writeBoolean(active);
+        packetBufferSender.writeLong(remainingMillis);
+    }
+
+    @Override
+    public void runServer(MinecraftServer minecraftServer, ServerPlayerEntity serverPlayerEntity) {
+        if (query) {
+            final long remaining = LiftDoorControlState.getHoldRemainingMillis(liftId);
+            Init.REGISTRY.sendPacketToClient(serverPlayerEntity,
+                    update(liftId, LiftDoorControlState.isHoldActive(liftId) && remaining > 0, remaining));
+        }
+    }
+
+    @Override
+    public void runClient() {
+        if (!query) {
+            LiftDoorControlState.updateClientHold(liftId, active, remainingMillis);
+        }
+    }
+}

--- a/fabric/src/main/resources/assets/yte/lang/en_us.json
+++ b/fabric/src/main/resources/assets/yte/lang/en_us.json
@@ -438,6 +438,11 @@
   "gui.yte.lift_levelling_speed_value": "Levelling speed: %s m/s",
   "gui.yte.lift_door_hold_on": "HOLD (door open extension): On",
   "gui.yte.lift_door_hold_off": "HOLD (door open extension): Off",
+  "gui.yte.lift_door_button_light_momentary": "Door button light: While pressed",
+  "gui.yte.lift_door_button_light_timed": "Door button light: 1 second after release",
+  "gui.yte.lift_door_button_light_automatic": "Door button light: Follow door operation",
+  "gui.yte.lift_floor_cancel_double_click": "Cancel selected floor: Double-click",
+  "gui.yte.lift_floor_cancel_long_press": "Cancel selected floor: Long press",
   "gui.yte.lift_hold_open": "HOLD",
   "block.yte.lift_track_magnetic_vane": "Lift Express-Zone Magnetic Vane"
 }

--- a/fabric/src/main/resources/assets/yte/lang/ja_jp.json
+++ b/fabric/src/main/resources/assets/yte/lang/ja_jp.json
@@ -433,6 +433,11 @@
   "gui.yte.lift_levelling_speed_value": "着床時の速度: %s m/s",
   "gui.yte.lift_door_hold_on": "HOLD (door open extension): On",
   "gui.yte.lift_door_hold_off": "HOLD (door open extension): Off",
+  "gui.yte.lift_door_button_light_momentary": "ドアボタン点灯：押している間",
+  "gui.yte.lift_door_button_light_timed": "ドアボタン点灯：離してから1秒間",
+  "gui.yte.lift_door_button_light_automatic": "ドアボタン点灯：ドア動作に連動",
+  "gui.yte.lift_floor_cancel_double_click": "選択階の取消：ダブルクリック",
+  "gui.yte.lift_floor_cancel_long_press": "選択階の取消：長押し",
   "gui.yte.lift_hold_open": "HOLD",
   "block.yte.lift_track_magnetic_vane": "通過階用遮光板"
 }

--- a/fabric/src/main/resources/assets/yte/lang/zh_cn.json
+++ b/fabric/src/main/resources/assets/yte/lang/zh_cn.json
@@ -433,6 +433,11 @@
   "gui.yte.lift_levelling_speed_value": "平层徐行速度：%s m/s",
   "gui.yte.lift_door_hold_on": "HOLD（门保持延长）：开",
   "gui.yte.lift_door_hold_off": "HOLD（门保持延长）：关",
+  "gui.yte.lift_door_button_light_momentary": "开关门按钮灯光：按下时亮起",
+  "gui.yte.lift_door_button_light_timed": "开关门按钮灯光：松开后延时 1 秒熄灭",
+  "gui.yte.lift_door_button_light_automatic": "开关门按钮灯光：跟随门动作",
+  "gui.yte.lift_floor_cancel_double_click": "取消已选楼层：双击",
+  "gui.yte.lift_floor_cancel_long_press": "取消已选楼层：长按",
   "gui.yte.lift_hold_open": "延时关门",
   "block.yte.lift_track_magnetic_vane": "电梯快速区间隔磁板"
 }

--- a/fabric/src/main/resources/assets/yte/lang/zh_hk.json
+++ b/fabric/src/main/resources/assets/yte/lang/zh_hk.json
@@ -433,6 +433,11 @@
   "gui.yte.lift_levelling_speed_value": "平層速度：%s m/s",
   "gui.yte.lift_door_hold_on": "HOLD（門保持延長）：開",
   "gui.yte.lift_door_hold_off": "HOLD（門保持延長）：關",
+  "gui.yte.lift_door_button_light_momentary": "開關門按鈕燈光：按下時亮起",
+  "gui.yte.lift_door_button_light_timed": "開關門按鈕燈光：鬆開後延時 1 秒熄滅",
+  "gui.yte.lift_door_button_light_automatic": "開關門按鈕燈光：跟隨門動作",
+  "gui.yte.lift_floor_cancel_double_click": "取消已選樓層：雙擊",
+  "gui.yte.lift_floor_cancel_long_press": "取消已選樓層：長按",
   "gui.yte.lift_hold_open": "延時關門",
   "block.yte.lift_track_magnetic_vane": "電梯快速區間隔磁板"
 }

--- a/forge/src/main/java/top/xfunny/core/data/YteData.java
+++ b/forge/src/main/java/top/xfunny/core/data/YteData.java
@@ -17,7 +17,8 @@ public abstract class YteData {
                         config.getId(), config.getUpSpeed(), config.getDownSpeed(),
                         config.getUpAcceleration(), config.getDownAcceleration(), config.getAdoDistance(),
                         config.getLevellingDistance(), config.getLevellingSpeed(), config.getMotionProfile(),
-                        config.isDoorHoldEnabled());
+                        config.isDoorHoldEnabled(), config.getDoorButtonLightMode(), config.getFloorCancelMode(),
+                        config.isFloorCancelWhileMovingAllowed());
             });
         } catch (Exception e) {
             YteCoreLogger.error("YteData sync error", e);

--- a/forge/src/main/java/top/xfunny/core/data/YteLiftConfig.java
+++ b/forge/src/main/java/top/xfunny/core/data/YteLiftConfig.java
@@ -2,6 +2,8 @@ package top.xfunny.core.data;
 
 import org.mtr.core.serializer.ReaderBase;
 import top.xfunny.core.generated.data.YteLiftConfigSchema;
+import top.xfunny.mod.LiftDoorButtonLightMode;
+import top.xfunny.mod.LiftFloorCancelMode;
 import top.xfunny.mod.LiftMotionProfile;
 
 public class YteLiftConfig extends YteLiftConfigSchema {
@@ -30,8 +32,18 @@ public class YteLiftConfig extends YteLiftConfigSchema {
     public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             LiftMotionProfile motionProfile, boolean doorHoldEnabled) {
+        this(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                LiftDoorButtonLightMode.MOMENTARY, LiftFloorCancelMode.DOUBLE_CLICK, false);
+    }
+
+    public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            LiftMotionProfile motionProfile, boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode,
+            LiftFloorCancelMode floorCancelMode, boolean floorCancelWhileMoving) {
         super(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
-                adoDistance, levellingDistance, levellingSpeed, motionProfile.name(), doorHoldEnabled);
+                adoDistance, levellingDistance, levellingSpeed, motionProfile.name(), doorHoldEnabled,
+                doorButtonLightMode.name(), floorCancelMode.name(), floorCancelWhileMoving);
     }
 
     public YteLiftConfig(ReaderBase readerBase) {
@@ -66,6 +78,16 @@ public class YteLiftConfig extends YteLiftConfigSchema {
 
     public boolean isDoorHoldEnabled() { return doorHoldEnabled; }
 
+    public LiftDoorButtonLightMode getDoorButtonLightMode() {
+        return LiftDoorButtonLightMode.fromSerializedName(doorButtonLightMode);
+    }
+
+    public LiftFloorCancelMode getFloorCancelMode() {
+        return LiftFloorCancelMode.fromSerializedName(floorCancelMode);
+    }
+
+    public boolean isFloorCancelWhileMovingAllowed() { return floorCancelWhileMoving; }
+
     public void setSpeed(double speed) {
         this.speed = clamp(speed, MIN_SPEED, MAX_SPEED);
     }
@@ -81,6 +103,18 @@ public class YteLiftConfig extends YteLiftConfigSchema {
     public void setLevellingSpeed(double levellingSpeed) { this.levellingSpeed = clamp(levellingSpeed, MIN_LEVELLING_SPEED, MAX_LEVELLING_SPEED); }
 
     public void setDoorHoldEnabled(boolean doorHoldEnabled) { this.doorHoldEnabled = doorHoldEnabled; }
+
+    public void setDoorButtonLightMode(LiftDoorButtonLightMode doorButtonLightMode) {
+        this.doorButtonLightMode = doorButtonLightMode.name();
+    }
+
+    public void setFloorCancelMode(LiftFloorCancelMode floorCancelMode) {
+        this.floorCancelMode = floorCancelMode.name();
+    }
+
+    public void setFloorCancelWhileMovingAllowed(boolean floorCancelWhileMoving) {
+        this.floorCancelWhileMoving = floorCancelWhileMoving;
+    }
 
     private static double clamp(double value, double min, double max) {
         return Math.max(min, Math.min(max, value));

--- a/forge/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
+++ b/forge/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
@@ -17,6 +17,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     protected double levellingDistance;
     protected double levellingSpeed;
     protected boolean doorHoldEnabled;
+    protected String doorButtonLightMode;
+    protected String floorCancelMode;
+    protected boolean floorCancelWhileMoving;
 
     private static final String KEY_LIFT_ID = "lift_id";
     private static final String KEY_SPEED = "speed";
@@ -29,6 +32,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     private static final String KEY_LEVELLING_DISTANCE = "levelling_distance";
     private static final String KEY_LEVELLING_SPEED = "levelling_speed";
     private static final String KEY_DOOR_HOLD_ENABLED = "door_hold_enabled";
+    private static final String KEY_DOOR_BUTTON_LIGHT_MODE = "door_button_light_mode";
+    private static final String KEY_FLOOR_CANCEL_MODE = "floor_cancel_mode";
+    private static final String KEY_FLOOR_CANCEL_WHILE_MOVING = "floor_cancel_while_moving";
 
     public static final double DEFAULT_SPEED = 10.0;
     public static final double DEFAULT_ACCELERATION = 4.0;
@@ -47,6 +53,8 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     public static final double MAX_LEVELLING_SPEED = 5;
     public static final double STEP = 0.5;
     public static final String DEFAULT_MOTION_PROFILE = "STANDARD";
+    public static final String DEFAULT_DOOR_BUTTON_LIGHT_MODE = "MOMENTARY";
+    public static final String DEFAULT_FLOOR_CANCEL_MODE = "DOUBLE_CLICK";
 
     protected YteLiftConfigSchema(long liftId, double speed, double acceleration, double adoDistance, double levellingDistance, double levellingSpeed) {
         this(liftId, speed, speed, acceleration, acceleration, true, adoDistance, levellingDistance, levellingSpeed,
@@ -69,6 +77,15 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             String motionProfile, boolean doorHoldEnabled) {
+        this(liftId, speed, downSpeed, acceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                DEFAULT_DOOR_BUTTON_LIGHT_MODE, DEFAULT_FLOOR_CANCEL_MODE, false);
+    }
+
+    protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            String motionProfile, boolean doorHoldEnabled, String doorButtonLightMode, String floorCancelMode,
+            boolean floorCancelWhileMoving) {
         this.liftId = liftId;
         this.speed = speed;
         this.acceleration = acceleration;
@@ -80,6 +97,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         this.levellingDistance = levellingDistance;
         this.levellingSpeed = levellingSpeed;
         this.doorHoldEnabled = doorHoldEnabled;
+        this.doorButtonLightMode = doorButtonLightMode;
+        this.floorCancelMode = floorCancelMode;
+        this.floorCancelWhileMoving = floorCancelWhileMoving;
     }
 
     protected YteLiftConfigSchema(ReaderBase readerBase) {
@@ -93,6 +113,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         levellingDistance = DEFAULT_LEVELLING_DISTANCE;
         levellingSpeed = DEFAULT_LEVELLING_SPEED;
         doorHoldEnabled = false;
+        doorButtonLightMode = DEFAULT_DOOR_BUTTON_LIGHT_MODE;
+        floorCancelMode = DEFAULT_FLOOR_CANCEL_MODE;
+        floorCancelWhileMoving = false;
         updateData(readerBase);
     }
 
@@ -109,6 +132,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         readerBase.unpackDouble(KEY_LEVELLING_DISTANCE, value -> levellingDistance = value);
         readerBase.unpackDouble(KEY_LEVELLING_SPEED, value -> levellingSpeed = value);
         doorHoldEnabled = readerBase.getBoolean(KEY_DOOR_HOLD_ENABLED, false);
+        doorButtonLightMode = readerBase.getString(KEY_DOOR_BUTTON_LIGHT_MODE, DEFAULT_DOOR_BUTTON_LIGHT_MODE);
+        floorCancelMode = readerBase.getString(KEY_FLOOR_CANCEL_MODE, DEFAULT_FLOOR_CANCEL_MODE);
+        floorCancelWhileMoving = readerBase.getBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, false);
     }
 
     @Override
@@ -124,6 +150,9 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         writerBase.writeDouble(KEY_LEVELLING_DISTANCE, levellingDistance);
         writerBase.writeDouble(KEY_LEVELLING_SPEED, levellingSpeed);
         writerBase.writeBoolean(KEY_DOOR_HOLD_ENABLED, doorHoldEnabled);
+        writerBase.writeString(KEY_DOOR_BUTTON_LIGHT_MODE, doorButtonLightMode);
+        writerBase.writeString(KEY_FLOOR_CANCEL_MODE, floorCancelMode);
+        writerBase.writeBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, floorCancelWhileMoving);
     }
 
     @Override


### PR DESCRIPTION
## 概述

统一电梯选层界面的按钮样式，并增加按钮灯光、长按、楼层取消及开门延长功能。

## 主要修改

- 将开门、关门和开门延长按钮改为与楼层按钮一致的样式。
- 为开关门及开门延长按钮增加指示灯。
- 楼层按钮和门控按钮按下后不再关闭选层界面，必须按 ESC 退出。
- 开门、关门按钮支持长按。
- 门控按钮始终允许点击；当前状态无法执行命令时，仅提供灯光反馈。

### 门控按钮灯光

可在电梯设置中选择：

- 按下时亮起，松开后熄灭。
- 按下时亮起，松开后延时 1 秒熄灭。

同时预留了根据电梯开关门状态自动亮灯的模式框架，但暂不开放选择。

### 开门延长

开门延长机制最初来源于 [PR #56](https://github.com/Yunzhu-Dev/Yunzhu-Transit-Extension/pull/56)。本 PR 在原有实现的基础上继续扩展状态保持、按钮灯光及呼梯响应逻辑。

- 启用后按钮持续亮起并保持电梯门开启。
- 按关门按钮可立即退出开门延长。
- 开门延长最长保持 60 秒，超时后自动退出并熄灯。
- 内呼或外呼登记不会退出开门延长，也不会触发关门。
- 延长期间登记目标后仍会显示运行方向，退出延长后才关门运行。
- 延长状态由服务端同步到客户端，重新打开选层界面后灯光状态仍然正确。

### 取消楼层

可在电梯设置中选择：

- 双击已登记楼层取消。
- 长按已登记楼层取消。

目前仅允许电梯静止且精确停层时取消。运行中取消的配置字段和扩展位置已经预留，但暂未启用，也不涉及运行途中就近停靠。

## 兼容性

- 现有电梯配置可继续读取。
- 新配置使用兼容默认值：
  - 门控灯光：按下时亮起。
  - 取消楼层：双击。
  - 运行中取消：关闭。
- 未修改任何 Gradle、构建脚本或构建配置。

## 测试

- `./gradlew :fabric:compileJava :forge:compileJava --no-daemon`
- `./gradlew :fabric:build :forge:build --no-daemon`
- Minecraft 1.20.1 游戏内手动测试通过。
- 已验证 Fabric 和 Forge 构建。
- 已验证语言 JSON 和 UTF-8 编码。

## 推荐的后续改进

以下功能不包含在本 PR 中，可在后续继续实现：

- 完整支持电梯运行时取消楼层，并在取消当前目标后重新计算运行路径，实现合理的就近停靠。
- 也可采用部分三菱电梯的逻辑：只有登记了两个或以上内呼楼层时，才允许取消其中一个楼层，避免误操作导致全部内呼被清除。
- 修正电梯停在当前楼层且门已经打开时的同层内呼、外呼响应，避免同层登记再次触发完整开门流程或重复开门。
