### PR TITLE
修复电梯门的 bug

### DIFF
--- a/fabric/src/main/java/top/xfunny/mixin/MixinLiftDoorBlockEntity.java
+++ b/fabric/src/main/java/top/xfunny/mixin/MixinLiftDoorBlockEntity.java
@@ -12,6 +12,7 @@ import org.mtr.mod.block.BlockPSDAPGDoorBase;
 import org.mtr.mod.block.IBlock;
 import org.mtr.mod.client.MinecraftClientData;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -23,6 +24,24 @@ import top.xfunny.mod.block.SchindlerQKS9Door1;
 
 @Mixin(value = BlockPSDAPGDoorBase.BlockEntityBase.class, remap = false)
 public abstract class MixinLiftDoorBlockEntity extends BlockEntityExtension {
+
+    /**
+     * Lifts whose landing doors stand very close together (for example with
+     * only one block between the doors) may still share a door if their
+     * ownership score is within this slack of the best-matching lift. The
+     * value is small enough that neighbouring shafts (several blocks apart)
+     * never fall inside it, but forgiving for imprecise builds.
+     */
+    @Unique
+    private static final double YTE_OWNERSHIP_SLACK = 4;
+
+    /**
+     * Squared-distance penalty per block of vertical mismatch when matching a
+     * door to the lift floor registered at its landing. Prefers floors on the
+     * exact level of the door over floors one block away.
+     */
+    @Unique
+    private static final double YTE_FLOOR_Y_MISMATCH_PENALTY = 100;
 
     protected MixinLiftDoorBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
         super(blockEntityType, blockPos, blockState);
@@ -39,47 +58,137 @@ public abstract class MixinLiftDoorBlockEntity extends BlockEntityExtension {
             doorPos = doorPos.down(1);
         }
 
-        boolean foundNearbyOpeningLift = false;
+        // MTR's doorway sweep (RenderVehicleHelper#canOpenDoors) opens every
+        // unlocked landing door within roughly two blocks of the car front,
+        // without knowing which lift a door belongs to. With lifts standing
+        // side by side whose landing doors are only one block apart, one
+        // lift's sweep reaches into the neighbour's door blocks and drags
+        // that door half open. Resolve which lift actually owns this landing
+        // door - among all lifts registered on this level, the one whose
+        // floor is horizontally closest to the door - and only let an opening
+        // owner (or a lift within the shared-shaft slack band) move it.
+        double bestScore = Double.POSITIVE_INFINITY;
+        boolean anyFloorOnLevel = false;
+        for (Lift lift : MinecraftClientData.getInstance().lifts) {
+            final Double score = yte$getOwnershipScore(lift, doorPos);
+            if (score != null) {
+                anyFloorOnLevel = true;
+                if (score < bestScore) {
+                    bestScore = score;
+                }
+            }
+        }
+
+        boolean allowed;
+        if (!anyFloorOnLevel) {
+            // No lift is registered anywhere near this landing; keep the
+            // legacy proximity behaviour so unlinked setups keep working.
+            allowed = yte$hasNearbyOpeningLift(doorPos);
+        } else {
+            allowed = false;
+            for (Lift lift : MinecraftClientData.getInstance().lifts) {
+                final Double score = yte$getOwnershipScore(lift, doorPos);
+                if (score != null && score <= bestScore + YTE_OWNERSHIP_SLACK && yte$isOpeningAtDoor(lift, doorPos)) {
+                    allowed = true;
+                    break;
+                }
+            }
+        }
+
+        if (!allowed) {
+            ci.cancel();
+        }
+    }
+
+    /**
+     * Score how well a lift matches this landing door: squared horizontal
+     * distance from the door to the lift's nearest floor on this level, plus
+     * a penalty per block of vertical mismatch. Returns {@code null} when the
+     * lift has no floor within one block of the door's level.
+     */
+    @Unique
+    private Double yte$getOwnershipScore(Lift lift, BlockPos doorPos) {
+        double bestScore = Double.POSITIVE_INFINITY;
+        for (LiftFloor floor : ((MixinLiftSchema) lift).getFloors()) {
+            final long dy = Math.abs(floor.getPosition().getY() - doorPos.getY());
+            if (dy > 1) {
+                continue;
+            }
+            final long dx = floor.getPosition().getX() - doorPos.getX();
+            final long dz = floor.getPosition().getZ() - doorPos.getZ();
+            final double score = dx * dx + dz * dz + dy * dy * YTE_FLOOR_Y_MISMATCH_PENALTY;
+            if (score < bestScore) {
+                bestScore = score;
+            }
+        }
+        return bestScore == Double.POSITIVE_INFINITY ? null : bestScore;
+    }
+
+    /**
+     * Legacy proximity rule kept for doors without any registered lift on
+     * their level: allow the door movement unless a nearby lift is currently
+     * opening at some other level.
+     */
+    @Unique
+    private boolean yte$hasNearbyOpeningLift(BlockPos doorPos) {
+        boolean foundHorizontallyNearOpeningLift = false;
         for (Lift lift : MinecraftClientData.getInstance().lifts) {
             if (!lift.hasCoolDown() || lift.getDoorValue() <= 0) {
                 continue;
             }
-
-            final MixinLiftSchema schema = (MixinLiftSchema) lift;
-            final LiftFloor targetFloor;
-            // Selecting a destination while the doors are still open must not
-            // immediately move the hall-door association to that destination.
-            // Use the instruction floor only once the lift is actually moving
-            // (the ADO/levelling phase); otherwise keep the current floor.
-            if (schema.getSpeed() == 0 || schema.getInstructions().isEmpty()) {
-                targetFloor = lift.getCurrentFloor();
-            } else {
-                final int targetFloorIndex = schema.getInstructions().get(0).getFloor();
-                if (targetFloorIndex < 0 || targetFloorIndex >= schema.getFloors().size()) {
-                    continue;
-                }
-                targetFloor = schema.getFloors().get(targetFloorIndex);
+            final LiftFloor targetFloor = yte$getTargetFloor(lift);
+            if (targetFloor == null) {
+                continue;
             }
-
-            final long targetX = targetFloor.getPosition().getX();
-            final long targetY = targetFloor.getPosition().getY();
-            final long targetZ = targetFloor.getPosition().getZ();
-
-            final double alignY = targetY + lift.getOffsetY();
-
             final double horizontalRange = Math.max(lift.getWidth(), lift.getDepth()) / 2 + 3;
-            if (Math.abs(doorPos.getX() - targetX) <= horizontalRange
-                    && Math.abs(doorPos.getZ() - targetZ) <= horizontalRange) {
-                foundNearbyOpeningLift = true;
+            if (Math.abs(doorPos.getX() - targetFloor.getPosition().getX()) <= horizontalRange
+                    && Math.abs(doorPos.getZ() - targetFloor.getPosition().getZ()) <= horizontalRange) {
+                foundHorizontallyNearOpeningLift = true;
+                final double alignY = targetFloor.getPosition().getY() + lift.getOffsetY();
                 if (doorPos.getY() + 1 >= alignY - 2 && doorPos.getY() <= alignY + 2) {
-                    return;
+                    return true;
                 }
             }
         }
+        return !foundHorizontallyNearOpeningLift;
+    }
 
-        if (foundNearbyOpeningLift) {
-            ci.cancel();
+    @Unique
+    private boolean yte$isOpeningAtDoor(Lift lift, BlockPos doorPos) {
+        if (!lift.hasCoolDown() || lift.getDoorValue() <= 0) {
+            return false;
         }
+
+        final LiftFloor targetFloor = yte$getTargetFloor(lift);
+        if (targetFloor == null) {
+            return false;
+        }
+
+        final double horizontalRange = Math.max(lift.getWidth(), lift.getDepth()) / 2 + 3;
+        if (Math.abs(doorPos.getX() - targetFloor.getPosition().getX()) > horizontalRange
+                || Math.abs(doorPos.getZ() - targetFloor.getPosition().getZ()) > horizontalRange) {
+            return false;
+        }
+
+        final double alignY = targetFloor.getPosition().getY() + lift.getOffsetY();
+        return doorPos.getY() + 1 >= alignY - 2 && doorPos.getY() <= alignY + 2;
+    }
+
+    @Unique
+    private LiftFloor yte$getTargetFloor(Lift lift) {
+        final MixinLiftSchema schema = (MixinLiftSchema) lift;
+        // Selecting a destination while the doors are still open must not
+        // immediately move the hall-door association to that destination.
+        // Use the instruction floor only once the lift is actually moving
+        // (the ADO/levelling phase); otherwise keep the current floor.
+        if (schema.getSpeed() == 0 || schema.getInstructions().isEmpty()) {
+            return lift.getCurrentFloor();
+        }
+        final int targetFloorIndex = schema.getInstructions().get(0).getFloor();
+        if (targetFloorIndex < 0 || targetFloorIndex >= schema.getFloors().size()) {
+            return null;
+        }
+        return schema.getFloors().get(targetFloorIndex);
     }
 
     private boolean yte$isLiftDoor() {

--- a/fabric/src/main/java/top/xfunny/mod/Keys.java
+++ b/fabric/src/main/java/top/xfunny/mod/Keys.java
@@ -2,6 +2,6 @@ package top.xfunny.mod;
 
 public interface Keys {
     String MOD_VERSION = "1.0.2-prerelease.3";
-    String BUILD_TIME = "260823-2034+0800";
+    String BUILD_TIME = "260824-1503+0800";
     String API_URL = "https://api.modrinth.com/v2/project/yunzhu-transit-extension/version";
 }


### PR DESCRIPTION
在先前提交构建出来的版本中，我发现一个问题：两个相邻（中间间隔 1 格）的电梯门，通过正常（指电梯正常到站）开门时出现：
<img width="1280" height="681" alt="61b9308ec593b44229f67b6672fa4a14_720" src="https://github.com/user-attachments/assets/8baaba3f-58da-4cf8-9c7f-46032008cb99" />
（一台电梯到站正常开门，旁边的电梯层门只开了半边）
于是我花了一些时间对齐进行了修复，修复了这个问题：
<img width="6016" height="3202" alt="QQ_1787555599998" src="https://github.com/user-attachments/assets/649bcb03-ee2b-4c0d-b6fb-3c5cbaf079fe" />
解决的方法是：
fabric/src/main/java/top/xfunny/mixin/MixinLiftDoorBlockEntity.java:52 重写了过滤逻辑：

所属判定：为每扇层门计算归属——在与其同一层（Y ±1）注册过楼层的电梯中，取楼层位置水平距离最近者（平方距离 + 每 1 格 Y 偏差 100 分惩罚）。
严格放行：只有“所属电梯”（或评分落在容差带 YTE_OWNERSHIP_SLACK 内、模拟共享井道的情况）本身正在开门（hasCoolDown && doorValue > 0）且满足原有水平/垂直对齐条件时，才允许 setDoorValue 生效。
保留旧行为：该层完全没注册任何电梯时，回退到原有的邻近放行逻辑，不影响未连接楼层的老存档/搭建方式；原有 ADO 预开门防误开判断也原样保留。
效果：A 梯开门只动自己的层门；旁边 1 格外属于 B 梯的层门不再被带动，而两台梯各自的门正常联动。建议进游戏用“两梯相邻、门距 1 格”的场景验证一次开关门与 ADO 预开门表现。

26.8.24