### PR TITLE
feat: add Mitsubishi NexWay arrival lantern strategy

### DIFF
--- a/fabric/src/main/java/top/xfunny/core/data/YteData.java
+++ b/fabric/src/main/java/top/xfunny/core/data/YteData.java
@@ -18,7 +18,7 @@ public abstract class YteData {
                         config.getUpAcceleration(), config.getDownAcceleration(), config.getAdoDistance(),
                         config.getLevellingDistance(), config.getLevellingSpeed(), config.getMotionProfile(),
                         config.isDoorHoldEnabled(), config.getDoorButtonLightMode(), config.getFloorCancelMode(),
-                        config.isFloorCancelWhileMovingAllowed());
+                        config.isFloorCancelWhileMovingAllowed(), config.getArrivalLanternTriggerMode());
                 top.xfunny.mod.config.YteLiftConfigStore.setLiftNumber(config.getId(), config.getLiftNumber());
             });
         } catch (Exception e) {

--- a/fabric/src/main/java/top/xfunny/core/data/YteLiftConfig.java
+++ b/fabric/src/main/java/top/xfunny/core/data/YteLiftConfig.java
@@ -2,6 +2,7 @@ package top.xfunny.core.data;
 
 import org.mtr.core.serializer.ReaderBase;
 import top.xfunny.core.generated.data.YteLiftConfigSchema;
+import top.xfunny.mod.lift.LiftArrivalLanternTriggerMode;
 import top.xfunny.mod.lift.LiftDoorButtonLightMode;
 import top.xfunny.mod.lift.LiftFloorCancelMode;
 import top.xfunny.mod.lift.LiftMotionProfile;
@@ -34,16 +35,29 @@ public class YteLiftConfig extends YteLiftConfigSchema {
             LiftMotionProfile motionProfile, boolean doorHoldEnabled) {
         this(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
                 adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
-                LiftDoorButtonLightMode.MOMENTARY, LiftFloorCancelMode.DOUBLE_CLICK, false, "");
+                LiftDoorButtonLightMode.MOMENTARY, LiftFloorCancelMode.DOUBLE_CLICK, false,
+                LiftArrivalLanternTriggerMode.DECELERATION, "");
     }
 
     public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             LiftMotionProfile motionProfile, boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode,
             LiftFloorCancelMode floorCancelMode, boolean floorCancelWhileMoving, String liftNumber) {
+        this(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                doorButtonLightMode, floorCancelMode, floorCancelWhileMoving,
+                LiftArrivalLanternTriggerMode.DECELERATION, liftNumber);
+    }
+
+    public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            LiftMotionProfile motionProfile, boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode,
+            LiftFloorCancelMode floorCancelMode, boolean floorCancelWhileMoving,
+            LiftArrivalLanternTriggerMode arrivalLanternTriggerMode, String liftNumber) {
         super(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
                 adoDistance, levellingDistance, levellingSpeed, motionProfile.name(), doorHoldEnabled,
-                doorButtonLightMode.name(), floorCancelMode.name(), floorCancelWhileMoving, liftNumber);
+                doorButtonLightMode.name(), floorCancelMode.name(), floorCancelWhileMoving,
+                arrivalLanternTriggerMode.name(), liftNumber);
     }
 
     public YteLiftConfig(ReaderBase readerBase) {
@@ -88,6 +102,10 @@ public class YteLiftConfig extends YteLiftConfigSchema {
 
     public boolean isFloorCancelWhileMovingAllowed() { return floorCancelWhileMoving; }
 
+    public LiftArrivalLanternTriggerMode getArrivalLanternTriggerMode() {
+        return LiftArrivalLanternTriggerMode.fromSerializedName(arrivalLanternTriggerMode);
+    }
+
     public String getLiftNumber() { return liftNumber; }
 
     public void setSpeed(double speed) {
@@ -116,6 +134,10 @@ public class YteLiftConfig extends YteLiftConfigSchema {
 
     public void setFloorCancelWhileMovingAllowed(boolean floorCancelWhileMoving) {
         this.floorCancelWhileMoving = floorCancelWhileMoving;
+    }
+
+    public void setArrivalLanternTriggerMode(LiftArrivalLanternTriggerMode arrivalLanternTriggerMode) {
+        this.arrivalLanternTriggerMode = arrivalLanternTriggerMode.name();
     }
 
     public void setLiftNumber(String liftNumber) {

--- a/fabric/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
+++ b/fabric/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
@@ -20,6 +20,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     protected String doorButtonLightMode;
     protected String floorCancelMode;
     protected boolean floorCancelWhileMoving;
+    protected String arrivalLanternTriggerMode;
     protected String liftNumber;
 
     private static final String KEY_LIFT_ID = "lift_id";
@@ -36,6 +37,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     private static final String KEY_DOOR_BUTTON_LIGHT_MODE = "door_button_light_mode";
     private static final String KEY_FLOOR_CANCEL_MODE = "floor_cancel_mode";
     private static final String KEY_FLOOR_CANCEL_WHILE_MOVING = "floor_cancel_while_moving";
+    private static final String KEY_ARRIVAL_LANTERN_TRIGGER_MODE = "arrival_lantern_trigger_mode";
     private static final String KEY_LIFT_NUMBER = "lift_number";
 
     public static final double DEFAULT_SPEED = 10.0;
@@ -57,6 +59,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     public static final String DEFAULT_MOTION_PROFILE = "STANDARD";
     public static final String DEFAULT_DOOR_BUTTON_LIGHT_MODE = "MOMENTARY";
     public static final String DEFAULT_FLOOR_CANCEL_MODE = "DOUBLE_CLICK";
+    public static final String DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE = "DECELERATION";
     public static final String DEFAULT_LIFT_NUMBER = "";
 
     protected YteLiftConfigSchema(long liftId, double speed, double acceleration, double adoDistance, double levellingDistance, double levellingSpeed) {
@@ -82,13 +85,24 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
             String motionProfile, boolean doorHoldEnabled) {
         this(liftId, speed, downSpeed, acceleration, downAcceleration, directionParametersLinked,
                 adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
-                DEFAULT_DOOR_BUTTON_LIGHT_MODE, DEFAULT_FLOOR_CANCEL_MODE, false, DEFAULT_LIFT_NUMBER);
+                DEFAULT_DOOR_BUTTON_LIGHT_MODE, DEFAULT_FLOOR_CANCEL_MODE, false,
+                DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE, DEFAULT_LIFT_NUMBER);
     }
 
     protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             String motionProfile, boolean doorHoldEnabled, String doorButtonLightMode, String floorCancelMode,
             boolean floorCancelWhileMoving, String liftNumber) {
+        this(liftId, speed, downSpeed, acceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                doorButtonLightMode, floorCancelMode, floorCancelWhileMoving,
+                DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE, liftNumber);
+    }
+
+    protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            String motionProfile, boolean doorHoldEnabled, String doorButtonLightMode, String floorCancelMode,
+            boolean floorCancelWhileMoving, String arrivalLanternTriggerMode, String liftNumber) {
         this.liftId = liftId;
         this.speed = speed;
         this.acceleration = acceleration;
@@ -103,6 +117,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         this.doorButtonLightMode = doorButtonLightMode;
         this.floorCancelMode = floorCancelMode;
         this.floorCancelWhileMoving = floorCancelWhileMoving;
+        this.arrivalLanternTriggerMode = arrivalLanternTriggerMode;
         this.liftNumber = liftNumber;
     }
 
@@ -120,6 +135,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         doorButtonLightMode = DEFAULT_DOOR_BUTTON_LIGHT_MODE;
         floorCancelMode = DEFAULT_FLOOR_CANCEL_MODE;
         floorCancelWhileMoving = false;
+        arrivalLanternTriggerMode = DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE;
         liftNumber = DEFAULT_LIFT_NUMBER;
         updateData(readerBase);
     }
@@ -140,6 +156,8 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         doorButtonLightMode = readerBase.getString(KEY_DOOR_BUTTON_LIGHT_MODE, DEFAULT_DOOR_BUTTON_LIGHT_MODE);
         floorCancelMode = readerBase.getString(KEY_FLOOR_CANCEL_MODE, DEFAULT_FLOOR_CANCEL_MODE);
         floorCancelWhileMoving = readerBase.getBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, false);
+        arrivalLanternTriggerMode = readerBase.getString(
+                KEY_ARRIVAL_LANTERN_TRIGGER_MODE, DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE);
         liftNumber = readerBase.getString(KEY_LIFT_NUMBER, DEFAULT_LIFT_NUMBER);
     }
 
@@ -159,6 +177,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         writerBase.writeString(KEY_DOOR_BUTTON_LIGHT_MODE, doorButtonLightMode);
         writerBase.writeString(KEY_FLOOR_CANCEL_MODE, floorCancelMode);
         writerBase.writeBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, floorCancelWhileMoving);
+        writerBase.writeString(KEY_ARRIVAL_LANTERN_TRIGGER_MODE, arrivalLanternTriggerMode);
         writerBase.writeString(KEY_LIFT_NUMBER, liftNumber);
     }
 

--- a/fabric/src/main/java/top/xfunny/mixin/MixinLift.java
+++ b/fabric/src/main/java/top/xfunny/mixin/MixinLift.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import top.xfunny.mod.config.YteLiftConfigStore;
 import top.xfunny.mod.Init;
+import top.xfunny.mod.lift.LiftArrivalLanternState;
 import top.xfunny.mod.lift.LiftDisplayDirection;
 import top.xfunny.mod.lift.LiftDisplayDirectionState;
 import top.xfunny.mod.lift.LiftDoorControlState;
@@ -216,6 +217,8 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
         if (isClientside()) {
             yte$updateDisplayFacts(levellingDistance);
             yte$updateDisplayDirection(millisElapsed);
+            LiftArrivalLanternState.get(id).update(
+                    LiftDisplayState.get(id), YteLiftConfigStore.getArrivalLanternTriggerMode(id));
         }
 
         if (getData() instanceof Simulator) {
@@ -290,12 +293,17 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
 
     @Unique
     private boolean yte$isExactlyAtFloor() {
+        return yte$getExactFloorIndex() >= 0;
+    }
+
+    @Unique
+    private int yte$getExactFloorIndex() {
         for (int i = 0; i < getFloors().size(); i++) {
             if (Math.abs(getRailProgress() - invokeGetProgress(i)) < 0.000001) {
-                return true;
+                return i;
             }
         }
-        return false;
+        return -1;
     }
 
     @Unique
@@ -308,6 +316,7 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
         int targetFloor = -1;
         double distanceToTarget = Double.POSITIVE_INFINITY;
         LiftDirection targetDirection = LiftDirection.NONE;
+        LiftDirection plannedArrivalDirection = LiftDirection.NONE;
 
         if (!getInstructions().isEmpty()) {
             final LiftInstruction instruction = getInstructions().get(0);
@@ -319,16 +328,47 @@ public abstract class MixinLift implements MixinLiftSchema, MixinLiftFields, Mix
                     : difference < 0
                     ? LiftDirection.DOWN
                     : instruction.getDirection();
+            plannedArrivalDirection = yte$getPlannedArrivalDirection(targetFloor, instruction, movementDirection);
         }
 
         final boolean doorCycle = getStoppingCoolDown() > 1 || lift.getDoorValue() != 0;
         final boolean levelling = moving && levellingDistance > 0 && distanceToTarget <= levellingDistance;
         final boolean idle = !moving && getInstructions().isEmpty() && !doorCycle;
         final int displayedFloor = lift.getFloorIndex(lift.getCurrentFloor().getPosition());
+        final int exactFloor = yte$getExactFloorIndex();
 
         LiftDisplayState.get(lift.getId()).update(
-                movementDirection, targetDirection, moving, levelling, doorCycle, idle,
-                displayedFloor, targetFloor, getSpeed(), distanceToTarget, getStoppingCoolDown());
+                movementDirection, targetDirection, plannedArrivalDirection,
+                moving, levelling, doorCycle, idle,
+                displayedFloor, exactFloor, targetFloor, getSpeed(), lift.getDoorValue(),
+                distanceToTarget, getStoppingCoolDown());
+    }
+
+    @Unique
+    private LiftDirection yte$getPlannedArrivalDirection(int targetFloor, LiftInstruction instruction,
+            LiftDirection movementDirection) {
+        final int floorCount = getFloors().size();
+        final boolean arrivingFromTravel = getSpeed() != 0
+                || LiftDisplayDirectionState.get(((Lift) (Object) this).getId()).movedSinceIdle;
+        if (arrivingFromTravel && targetFloor == floorCount - 1) {
+            return LiftDirection.DOWN;
+        }
+        if (arrivingFromTravel && targetFloor == 0) {
+            return LiftDirection.UP;
+        }
+        if (instruction.getDirection() != LiftDirection.NONE) {
+            return instruction.getDirection();
+        }
+        if (getInstructions().size() > 1) {
+            final int followingFloor = getInstructions().get(1).getFloor();
+            if (followingFloor > targetFloor) {
+                return LiftDirection.UP;
+            }
+            if (followingFloor < targetFloor) {
+                return LiftDirection.DOWN;
+            }
+        }
+        return movementDirection;
     }
 
     @Unique

--- a/fabric/src/main/java/top/xfunny/mixin/MixinLiftCustomizationScreen.java
+++ b/fabric/src/main/java/top/xfunny/mixin/MixinLiftCustomizationScreen.java
@@ -28,6 +28,7 @@ import top.xfunny.mod.client.InitClient;
 import top.xfunny.mod.client.YteMinecraftClientData;
 import top.xfunny.mod.config.YteLiftConfigStore;
 import top.xfunny.mod.packet.YtePacketUpdateData;
+import top.xfunny.mod.lift.LiftArrivalLanternTriggerMode;
 import top.xfunny.mod.lift.LiftDoorButtonLightMode;
 import top.xfunny.mod.lift.LiftFloorCancelMode;
 import top.xfunny.mod.lift.LiftMotionProfile;
@@ -123,6 +124,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique private ButtonWidgetExtension yte$doorHoldButton;
     @Unique private ButtonWidgetExtension yte$doorButtonLightModeButton;
     @Unique private ButtonWidgetExtension yte$floorCancelModeButton;
+    @Unique private ButtonWidgetExtension yte$arrivalLanternTriggerModeButton;
     @Unique private TextFieldWidgetExtension yte$speedField;
     @Unique private TextFieldWidgetExtension yte$accelerationField;
     @Unique private TextFieldWidgetExtension yte$downSpeedField;
@@ -160,6 +162,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique private LiftDoorButtonLightMode yte$lastSentDoorButtonLightMode = LiftDoorButtonLightMode.MOMENTARY;
     @Unique private LiftFloorCancelMode yte$floorCancelMode = LiftFloorCancelMode.DOUBLE_CLICK;
     @Unique private LiftFloorCancelMode yte$lastSentFloorCancelMode = LiftFloorCancelMode.DOUBLE_CLICK;
+    @Unique private LiftArrivalLanternTriggerMode yte$arrivalLanternTriggerMode = LiftArrivalLanternTriggerMode.DECELERATION;
+    @Unique private LiftArrivalLanternTriggerMode yte$lastSentArrivalLanternTriggerMode = LiftArrivalLanternTriggerMode.DECELERATION;
     @Unique private String yte$liftNumber = "";
     @Unique private String yte$lastSentLiftNumber = "";
     @Unique private double yte$lastSentAdoDistance = -1;
@@ -197,6 +201,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$doorHoldEnabled = config != null && config.isDoorHoldEnabled();
         yte$doorButtonLightMode = config == null ? LiftDoorButtonLightMode.MOMENTARY : config.getDoorButtonLightMode();
         yte$floorCancelMode = config == null ? LiftFloorCancelMode.DOUBLE_CLICK : config.getFloorCancelMode();
+        yte$arrivalLanternTriggerMode = config == null
+                ? LiftArrivalLanternTriggerMode.DECELERATION : config.getArrivalLanternTriggerMode();
         yte$liftNumber = config == null ? "" : config.getLiftNumber();
         final double currentAdoDistance = config != null ? config.getAdoDistance() : YteLiftConfig.DEFAULT_ADO_DISTANCE;
         final double currentLevellingDistance = config != null ? config.getLevellingDistance() : YteLiftConfig.DEFAULT_LEVELLING_DISTANCE;
@@ -243,6 +249,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 TextHelper.literal(""), button -> yte$toggleDoorButtonLightMode());
         yte$floorCancelModeButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
                 TextHelper.literal(""), button -> yte$toggleFloorCancelMode());
+        yte$arrivalLanternTriggerModeButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
+                TextHelper.literal(""), button -> yte$toggleArrivalLanternTriggerMode());
 
         yte$tabSizeButton = new ButtonWidgetExtension(0, 0, 0, IGui.SQUARE_SIZE,
                 TextHelper.translatable("gui.yte.lift_tab_base"), button -> yte$onSelectTab(TAB_BASE));
@@ -275,6 +283,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$lastSentDoorHoldEnabled = yte$doorHoldEnabled;
         yte$lastSentDoorButtonLightMode = yte$doorButtonLightMode;
         yte$lastSentFloorCancelMode = yte$floorCancelMode;
+        yte$lastSentArrivalLanternTriggerMode = yte$arrivalLanternTriggerMode;
         yte$lastSentLiftNumber = yte$liftNumber;
     }
 
@@ -306,6 +315,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         addChild(new ClickableWidget(yte$doorHoldButton));
         addChild(new ClickableWidget(yte$doorButtonLightModeButton));
         addChild(new ClickableWidget(yte$floorCancelModeButton));
+        addChild(new ClickableWidget(yte$arrivalLanternTriggerModeButton));
         addChild(new ClickableWidget(yte$sliderSpeed));
         addChild(new ClickableWidget(yte$sliderAcceleration));
         addChild(new ClickableWidget(yte$sliderDownSpeed));
@@ -410,6 +420,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 yte$positionFullWidth(yte$doorHoldButton, 1);
                 yte$positionFullWidth(yte$doorButtonLightModeButton, 2);
                 yte$positionFullWidth(yte$floorCancelModeButton, 3);
+                yte$positionFullWidth(yte$arrivalLanternTriggerModeButton, 4);
                 break;
             default:
                 break;
@@ -440,7 +451,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
             case TAB_LEVEL:
                 return 6;
             case TAB_DOOR:
-                return 3;
+                return 4;
             default:
                 return 1;
         }
@@ -575,6 +586,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 || yte$doorHoldEnabled != yte$lastSentDoorHoldEnabled
                 || yte$doorButtonLightMode != yte$lastSentDoorButtonLightMode
                 || yte$floorCancelMode != yte$lastSentFloorCancelMode
+                || yte$arrivalLanternTriggerMode != yte$lastSentArrivalLanternTriggerMode
                 || !liftNumber.equals(yte$lastSentLiftNumber)) {
             yte$lastSentSpeed = upSpeed;
             yte$lastSentDownSpeed = downSpeed;
@@ -588,16 +600,18 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
             yte$lastSentDoorHoldEnabled = yte$doorHoldEnabled;
             yte$lastSentDoorButtonLightMode = yte$doorButtonLightMode;
             yte$lastSentFloorCancelMode = yte$floorCancelMode;
+            yte$lastSentArrivalLanternTriggerMode = yte$arrivalLanternTriggerMode;
             yte$liftNumber = liftNumber;
             yte$lastSentLiftNumber = liftNumber;
 
             final long liftId = lift.getId();
             final YteLiftConfig config = new YteLiftConfig(liftId, upSpeed, downSpeed, upAccel, downAccel,
                     yte$directionParametersLinked, adoDistance, levellingDistance, levellingSpeed, yte$motionProfile,
-                    yte$doorHoldEnabled, yte$doorButtonLightMode, yte$floorCancelMode, false, liftNumber);
+                    yte$doorHoldEnabled, yte$doorButtonLightMode, yte$floorCancelMode, false,
+                    yte$arrivalLanternTriggerMode, liftNumber);
             YteLiftConfigStore.put(liftId, upSpeed, downSpeed, upAccel, downAccel,
                     adoDistance, levellingDistance, levellingSpeed, yte$motionProfile, yte$doorHoldEnabled,
-                    yte$doorButtonLightMode, yte$floorCancelMode, false);
+                    yte$doorButtonLightMode, yte$floorCancelMode, false, yte$arrivalLanternTriggerMode);
             YteLiftConfigStore.setLiftNumber(liftId, liftNumber);
 
             final YteUpdateDataRequest request = new YteUpdateDataRequest(
@@ -708,6 +722,12 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
     @Unique
     private void yte$toggleFloorCancelMode() {
         yte$floorCancelMode = yte$floorCancelMode.next();
+        yte$updateModeWidgets();
+    }
+
+    @Unique
+    private void yte$toggleArrivalLanternTriggerMode() {
+        yte$arrivalLanternTriggerMode = yte$arrivalLanternTriggerMode.next();
         yte$updateModeWidgets();
     }
 
@@ -826,6 +846,7 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
         yte$doorHoldButton.setVisibleMapped(doorTab);
         yte$doorButtonLightModeButton.setVisibleMapped(doorTab);
         yte$floorCancelModeButton.setVisibleMapped(doorTab);
+        yte$arrivalLanternTriggerModeButton.setVisibleMapped(doorTab);
 
         // 运行参数：滑块/文本框
         yte$sliderSpeed.setVisibleMapped(motionTab && !yte$professionalMode);
@@ -861,6 +882,8 @@ public abstract class MixinLiftCustomizationScreen extends MTRScreenBase {
                 yte$doorButtonLightMode.getTranslationKey()).data));
         yte$floorCancelModeButton.setMessage2(new Text(TextHelper.translatable(
                 yte$floorCancelMode.getTranslationKey()).data));
+        yte$arrivalLanternTriggerModeButton.setMessage2(new Text(TextHelper.translatable(
+                yte$arrivalLanternTriggerMode.getTranslationKey()).data));
     }
 
     @Unique

--- a/fabric/src/main/java/top/xfunny/mod/block/base/LiftButtonsBase.java
+++ b/fabric/src/main/java/top/xfunny/mod/block/base/LiftButtonsBase.java
@@ -15,7 +15,16 @@ import org.mtr.mod.packet.PacketPressLiftButton;
 import top.xfunny.mod.*;
 import top.xfunny.mod.Items;
 import top.xfunny.mod.keymapping.DefaultButtonsKeyMapping;
+import top.xfunny.mod.config.YteLiftConfigStore;
+import top.xfunny.mod.lift.LiftArrivalLanternContext;
+import top.xfunny.mod.lift.LiftArrivalLanternDecision;
+import top.xfunny.mod.lift.LiftArrivalLanternDisplayPhase;
+import top.xfunny.mod.lift.LiftArrivalLanternAssignmentProvider;
+import top.xfunny.mod.lift.LiftArrivalLanternFlashPattern;
+import top.xfunny.mod.lift.LiftArrivalLanternPolicy;
+import top.xfunny.mod.lift.LiftArrivalLanternState;
 import top.xfunny.mod.lift.LiftDisplayDirectionState;
+import top.xfunny.mod.lift.LiftDisplayState;
 import top.xfunny.mod.lift.LiftFloorRegistry;
 import top.xfunny.mod.lift.LiftLanternController;
 import top.xfunny.mod.util.TransformPositionX;
@@ -233,13 +242,28 @@ public abstract class LiftButtonsBase extends BlockExtension implements Directio
         public final boolean justTriggered;
         /** 最近一部已登记本层指令的电梯距离本层的楼层数，无相关电梯时为 -1 */
         public final int distanceToNearestLift;
+        /** Policy-selected flash pattern; legacy renderers may ignore it. */
+        public final LiftArrivalLanternFlashPattern flashPattern;
+        /** Optional policy-selected sound id/cue for future brand strategies. */
+        @Nullable public final String soundCue;
+        public final long phaseStartMillis;
 
         LanternState(boolean upActive, boolean downActive, LanternPhase phase, boolean justTriggered, int distanceToNearestLift) {
+            this(upActive, downActive, phase, justTriggered, distanceToNearestLift,
+                    LiftArrivalLanternFlashPattern.STEADY, null, 0);
+        }
+
+        LanternState(boolean upActive, boolean downActive, LanternPhase phase, boolean justTriggered,
+                int distanceToNearestLift, LiftArrivalLanternFlashPattern flashPattern,
+                @Nullable String soundCue, long phaseStartMillis) {
             this.upActive = upActive;
             this.downActive = downActive;
             this.phase = phase;
             this.justTriggered = justTriggered;
             this.distanceToNearestLift = distanceToNearestLift;
+            this.flashPattern = flashPattern;
+            this.soundCue = soundCue;
+            this.phaseStartMillis = phaseStartMillis;
         }
     }
 
@@ -257,9 +281,10 @@ public abstract class LiftButtonsBase extends BlockExtension implements Directio
         /** @deprecated 请使用 {@link #getLanternState} 的 justTriggered 替代。保留以兼容未迁移的 Screen 渲染类。 */
         @Deprecated
         public boolean lastDownActive = false;
-        /** 用于边沿检测的上一帧状态，按 trackPosition 独立存储（避免多楼层共享导致声音重叠） */
-        private final java.util.Map<BlockPos, boolean[]> lanternPrevState = new java.util.HashMap<>();
+        /** 每个轨道楼层、每部电梯最后观察到的触发序号，用于保证到站音只播放一次。 */
+        private final java.util.Map<BlockPos, java.util.Map<Long, Long>> lanternTriggerSequences = new java.util.HashMap<>();
         private LiftDirection pressedButtonDirection;
+        private long pressedButtonAtMillis;
         private DefaultButtonsKeyMapping keyMapping = new DefaultButtonsKeyMapping();
 
         public BlockEntityBase(BlockEntityType<?> type, BlockPos blockPos, BlockState blockState) {
@@ -351,48 +376,97 @@ public abstract class LiftButtonsBase extends BlockExtension implements Directio
          * @return 到站灯状态，绝不会为 null
          */
         public LanternState getLanternState(BlockPos trackPosition) {
+            return getLanternState(trackPosition, LiftArrivalLanternPolicy.DEFAULT);
+        }
+
+        /**
+         * Policy extension point for brand-specific advance notice, flash and
+         * sound strategies. The no-policy overload preserves current behavior.
+         */
+        public LanternState getLanternState(BlockPos trackPosition, LiftArrivalLanternPolicy policy) {
+            return getLanternState(trackPosition, policy, LiftArrivalLanternAssignmentProvider.NONE);
+        }
+
+        public LanternState getLanternState(BlockPos trackPosition, LiftArrivalLanternPolicy policy,
+                LiftArrivalLanternAssignmentProvider assignmentProvider) {
             boolean upActive = false;
             boolean downActive = false;
             LanternPhase phase = LanternPhase.IDLE;
             int minDistance = Integer.MAX_VALUE;
+            boolean justTriggered = false;
+            LiftArrivalLanternFlashPattern selectedFlashPattern = LiftArrivalLanternFlashPattern.STEADY;
+            String selectedSoundCue = null;
+            long selectedPhaseStartMillis = 0;
+            final long currentMillis = System.currentTimeMillis();
+            final java.util.Map<Long, Long> seenTriggerSequences = lanternTriggerSequences.computeIfAbsent(
+                    trackPosition, ignored -> new java.util.HashMap<>());
 
             for (Lift lift : MinecraftClientData.getInstance().lifts) {
                 final int floorIndex = lift.getFloorIndex(Init.blockPosToPosition(trackPosition));
                 if (floorIndex < 0) continue;
 
-                final boolean doorOpen = lift.getDoorValue() != 0;
+                final LiftArrivalLanternState arrivalState = LiftArrivalLanternState.get(lift.getId());
                 final int currentLiftFloorIdx = lift.getFloorIndex(lift.getCurrentFloor().getPosition());
-                final boolean atThisFloor = (currentLiftFloorIdx == floorIndex);
                 final int distance = Math.abs(currentLiftFloorIdx - floorIndex);
-
-                boolean hasUp = false;
-                boolean hasDown = false;
-                for (LiftDirection dir : lift.hasInstruction(floorIndex)) {
-                    if (dir == LiftDirection.UP) hasUp = true;
-                    if (dir == LiftDirection.DOWN) hasDown = true;
+                final LiftArrivalLanternContext context = new LiftArrivalLanternContext(
+                        LiftDisplayState.get(lift.getId()), arrivalState,
+                        YteLiftConfigStore.getArrivalLanternTriggerMode(lift.getId()), floorIndex, distance,
+                        pressedButtonDirection == null ? LiftDirection.NONE : pressedButtonDirection,
+                        pressedButtonAtMillis, currentMillis,
+                        assignmentProvider == null ? null : assignmentProvider.getAssignment(lift.getId(), floorIndex));
+                final LiftArrivalLanternDecision decision = policy == null
+                        ? LiftArrivalLanternDecision.inactive() : policy.evaluate(context);
+                if (decision == null || !decision.isActive()) {
+                    continue;
                 }
 
-                if (hasUp || hasDown) {
-                    phase = (doorOpen && atThisFloor) ? LanternPhase.ARRIVED : LanternPhase.APPROACHING;
-                    upActive = upActive || hasUp;
-                    downActive = downActive || hasDown;
-                    minDistance = Math.min(minDistance, distance);
-                } else if (pressedButtonDirection != null && doorOpen && atThisFloor) {
-                    if (phase.ordinal() < LanternPhase.CALL_REGISTERED.ordinal()) {
-                        phase = LanternPhase.CALL_REGISTERED;
+                final LiftDirection direction = decision.getDirection();
+                final boolean lightVisible = decision.getFlashPattern().isLit(
+                        currentMillis, decision.getPhaseStartMillis());
+
+                if (lightVisible && direction == LiftDirection.UP) {
+                    upActive = true;
+                } else if (lightVisible && direction == LiftDirection.DOWN) {
+                    downActive = true;
+                }
+                final LanternPhase decisionPhase = yte$toLegacyLanternPhase(decision.getPhase());
+                if (decisionPhase.ordinal() > phase.ordinal()) {
+                    phase = decisionPhase;
+                    selectedFlashPattern = decision.getFlashPattern();
+                    selectedSoundCue = decision.getSoundCue();
+                    selectedPhaseStartMillis = decision.getPhaseStartMillis();
+                } else if (selectedSoundCue == null && decision.getSoundCue() != null) {
+                    selectedSoundCue = decision.getSoundCue();
+                }
+                minDistance = Math.min(minDistance, distance);
+
+                final long eventSequence = decision.getEventSequence();
+                if (eventSequence > 0) {
+                    final Long previousSequence = seenTriggerSequences.put(lift.getId(), eventSequence);
+                    if (previousSequence == null || previousSequence != eventSequence) {
+                        justTriggered = true;
                     }
-                    if (pressedButtonDirection == LiftDirection.UP) upActive = true;
-                    if (pressedButtonDirection == LiftDirection.DOWN) downActive = true;
                 }
             }
 
-            // 边沿检测：按 trackPosition 独立追踪，避免多轨道楼层共享状态导致声音重叠
-            final boolean[] prev = lanternPrevState.computeIfAbsent(trackPosition, k -> new boolean[]{false, false});
-            final boolean justTriggered = (upActive && !prev[0]) || (downActive && !prev[1]);
-            prev[0] = upActive;
-            prev[1] = downActive;
+            return new LanternState(upActive, downActive, phase, justTriggered,
+                    minDistance == Integer.MAX_VALUE ? -1 : minDistance,
+                    selectedFlashPattern, selectedSoundCue, selectedPhaseStartMillis);
+        }
 
-            return new LanternState(upActive, downActive, phase, justTriggered, minDistance == Integer.MAX_VALUE ? -1 : minDistance);
+        private static LanternPhase yte$toLegacyLanternPhase(LiftArrivalLanternDisplayPhase phase) {
+            switch (phase) {
+                case CALL_REGISTERED:
+                    return LanternPhase.CALL_REGISTERED;
+                case APPROACHING:
+                    return LanternPhase.APPROACHING;
+                case ARRIVED:
+                case CLOSING:
+                    return LanternPhase.ARRIVED;
+                case IDLE:
+                default:
+                    return LanternPhase.IDLE;
+            }
         }
 
         @Override
@@ -402,6 +476,9 @@ public abstract class LiftButtonsBase extends BlockExtension implements Directio
         @Override
         public ObjectOpenHashSet<BlockPos> getLiftButtonPositions() { return liftButtonPositions; }
         public LiftDirection getPressedButtonDirection() { return pressedButtonDirection; }
-        public void setPressedButtonDirection(LiftDirection direction) { this.pressedButtonDirection = direction; }
+        public void setPressedButtonDirection(LiftDirection direction) {
+            pressedButtonDirection = direction;
+            pressedButtonAtMillis = System.currentTimeMillis();
+        }
     }
 }

--- a/fabric/src/main/java/top/xfunny/mod/client/InitClient.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/InitClient.java
@@ -9,7 +9,11 @@ import top.xfunny.mod.BlockEntityTypes;
 import top.xfunny.mod.Blocks;
 import top.xfunny.mod.Init;
 import top.xfunny.mod.Items;
+import top.xfunny.mod.lift.LiftArrivalLanternState;
+import top.xfunny.mod.lift.LiftDisplayDirectionState;
+import top.xfunny.mod.lift.LiftDisplayState;
 import top.xfunny.mod.lift.LiftDoorControlState;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.client.render.*;
 import top.xfunny.mod.client.resource.FontList;
 import top.xfunny.mod.client.sound.SoundPlaybackManager;
@@ -29,6 +33,10 @@ public final class InitClient {
         // 重置 YTE 客户端数据
         YteMinecraftClientData.reset();
         YteLiftConfigStore.clear();
+        LiftArrivalLanternState.clear();
+        LiftDisplayState.clear();
+        LiftDisplayDirectionState.clear();
+        MitsubishiNexWayLanternPolicy.INSTANCE.clear();
         LiftDoorControlState.clearClientState();
 
         initializeConfig();
@@ -402,6 +410,10 @@ public final class InitClient {
             MinecraftClientData.reset();
             YteMinecraftClientData.reset();
             YteLiftConfigStore.clear();
+            LiftArrivalLanternState.clear();
+            LiftDisplayState.clear();
+            LiftDisplayDirectionState.clear();
+            MitsubishiNexWayLanternPolicy.INSTANCE.clear();
             LiftDoorControlState.clearClientState();
             lastMillis = System.currentTimeMillis();
             gameMillis = 0;

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern1Horizontal.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern1Horizontal.java
@@ -20,6 +20,7 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
 
 import java.util.Comparator;
@@ -161,10 +162,6 @@ public class RenderMitsubishiNexWayLantern1Horizontal<T extends LiftButtonsBase.
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        final boolean enableCallFlash = true;
-        final boolean enableApproachFlash = false;
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
@@ -172,21 +169,20 @@ public class RenderMitsubishiNexWayLantern1Horizontal<T extends LiftButtonsBase.
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
             });
 
-            LiftButtonsBase.LanternState state = blockEntity.getLanternState(trackPosition);
-            final boolean useFlash = (state.phase == LiftButtonsBase.LanternPhase.CALL_REGISTERED && enableCallFlash)
-                    || ((state.phase == LiftButtonsBase.LanternPhase.APPROACHING
-                         || state.phase == LiftButtonsBase.LanternPhase.ARRIVED) && enableApproachFlash);
+            LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
 
-            if (state.downActive && (!useFlash || flash)) {
+            if (state.downActive) {
                 downLanternLeft.activate();
                 downLanternRight.activate();
             }
-            if (state.upActive && (!useFlash || flash)) {
+            if (state.upActive) {
                 upLanternLeft.activate();
                 upLanternRight.activate();
             }
-            if (state.justTriggered) {
-                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
             }
         });
 

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern1Vertical.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern1Vertical.java
@@ -20,6 +20,7 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
 
 import java.util.Comparator;
@@ -162,10 +163,6 @@ public class RenderMitsubishiNexWayLantern1Vertical<T extends LiftButtonsBase.Bl
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        final boolean enableCallFlash = true;
-        final boolean enableApproachFlash = false;
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
@@ -173,21 +170,20 @@ public class RenderMitsubishiNexWayLantern1Vertical<T extends LiftButtonsBase.Bl
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
             });
 
-            LiftButtonsBase.LanternState state = blockEntity.getLanternState(trackPosition);
-            final boolean useFlash = (state.phase == LiftButtonsBase.LanternPhase.CALL_REGISTERED && enableCallFlash)
-                    || ((state.phase == LiftButtonsBase.LanternPhase.APPROACHING
-                         || state.phase == LiftButtonsBase.LanternPhase.ARRIVED) && enableApproachFlash);
+            LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
 
-            if (state.downActive && (!useFlash || flash)) {
+            if (state.downActive) {
                 downLanternLeft.activate();
                 downLanternRight.activate();
             }
-            if (state.upActive && (!useFlash || flash)) {
+            if (state.upActive) {
                 upLanternLeft.activate();
                 upLanternRight.activate();
             }
-            if (state.justTriggered) {
-                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
             }
         });
 

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern2Horizontal.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern2Horizontal.java
@@ -23,6 +23,7 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
 
 import java.util.Comparator;
@@ -135,10 +136,6 @@ public class RenderMitsubishiNexWayLantern2Horizontal<T extends LiftButtonsBase.
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        final boolean enableCallFlash = true;
-        final boolean enableApproachFlash = false;
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
@@ -146,21 +143,20 @@ public class RenderMitsubishiNexWayLantern2Horizontal<T extends LiftButtonsBase.
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
             });
 
-            LiftButtonsBase.LanternState state = blockEntity.getLanternState(trackPosition);
-            final boolean useFlash = (state.phase == LiftButtonsBase.LanternPhase.CALL_REGISTERED && enableCallFlash)
-                    || ((state.phase == LiftButtonsBase.LanternPhase.APPROACHING
-                         || state.phase == LiftButtonsBase.LanternPhase.ARRIVED) && enableApproachFlash);
+            LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
 
-            if (state.downActive && (!useFlash || flash)) {
+            if (state.downActive) {
                 downLanternLeft.activate();
                 downLanternRight.activate();
             }
-            if (state.upActive && (!useFlash || flash)) {
+            if (state.upActive) {
                 upLanternLeft.activate();
                 upLanternRight.activate();
             }
-            if (state.justTriggered) {
-                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
             }
         });
 

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern2Vertical.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern2Vertical.java
@@ -23,6 +23,7 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
 
 import java.util.Comparator;
@@ -136,10 +137,6 @@ public class RenderMitsubishiNexWayLantern2Vertical<T extends LiftButtonsBase.Bl
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        final boolean enableCallFlash = true;
-        final boolean enableApproachFlash = false;
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
@@ -147,21 +144,20 @@ public class RenderMitsubishiNexWayLantern2Vertical<T extends LiftButtonsBase.Bl
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
             });
 
-            LiftButtonsBase.LanternState state = blockEntity.getLanternState(trackPosition);
-            final boolean useFlash = (state.phase == LiftButtonsBase.LanternPhase.CALL_REGISTERED && enableCallFlash)
-                    || ((state.phase == LiftButtonsBase.LanternPhase.APPROACHING
-                         || state.phase == LiftButtonsBase.LanternPhase.ARRIVED) && enableApproachFlash);
+            LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
 
-            if (state.downActive && (!useFlash || flash)) {
+            if (state.downActive) {
                 downLanternLeft.activate();
                 downLanternRight.activate();
             }
-            if (state.upActive && (!useFlash || flash)) {
+            if (state.upActive) {
                 upLanternLeft.activate();
                 upLanternRight.activate();
             }
-            if (state.justTriggered) {
-                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
             }
         });
 

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern3.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayLantern3.java
@@ -23,6 +23,7 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
 
 import java.util.Comparator;
@@ -134,10 +135,6 @@ public class RenderMitsubishiNexWayLantern3<T extends LiftButtonsBase.BlockEntit
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        final boolean enableCallFlash = true;
-        final boolean enableApproachFlash = false;
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
@@ -145,21 +142,20 @@ public class RenderMitsubishiNexWayLantern3<T extends LiftButtonsBase.BlockEntit
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
             });
 
-            LiftButtonsBase.LanternState state = blockEntity.getLanternState(trackPosition);
-            final boolean useFlash = (state.phase == LiftButtonsBase.LanternPhase.CALL_REGISTERED && enableCallFlash)
-                    || ((state.phase == LiftButtonsBase.LanternPhase.APPROACHING
-                         || state.phase == LiftButtonsBase.LanternPhase.ARRIVED) && enableApproachFlash);
+            LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
 
-            if (state.downActive && (!useFlash || flash)) {
+            if (state.downActive) {
                 downLanternLeft.activate();
                 downLanternRight.activate();
             }
-            if (state.upActive && (!useFlash || flash)) {
+            if (state.upActive) {
                 upLanternLeft.activate();
                 upLanternRight.activate();
             }
-            if (state.justTriggered) {
-                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
             }
         });
 

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayScreen1.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayScreen1.java
@@ -3,7 +3,6 @@ package top.xfunny.mod.client.render;
 import org.mtr.core.data.Lift;
 import org.mtr.core.data.LiftDirection;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import org.mtr.mapping.holder.*;
 import org.mtr.mapping.mapper.BlockEntityRenderer;
@@ -12,7 +11,6 @@ import org.mtr.mapping.mapper.GraphicsHolder;
 import org.mtr.mapping.mapper.PlayerHelper;
 import org.mtr.mod.block.IBlock;
 import org.mtr.mod.data.IGui;
-import org.mtr.mod.render.RenderLifts;
 import org.mtr.mod.render.StoredMatrixTransformations;
 import top.xfunny.mod.Init;
 import top.xfunny.mod.block.MitsubishiNexWayScreen1Even;
@@ -24,12 +22,11 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
 import top.xfunny.mod.util.ClientGetLiftDetails;
 
 import java.util.Comparator;
-
-import static org.mtr.core.data.LiftDirection.NONE;
 
 public class RenderMitsubishiNexWayScreen1<T extends LiftButtonsBase.BlockEntityBase> extends BlockEntityRenderer<T> implements DirectionHelper, IGui, IBlock {
     private static final int PRESSED_COLOR = 0xFFFEE1A9;
@@ -176,110 +173,27 @@ public class RenderMitsubishiNexWayScreen1<T extends LiftButtonsBase.BlockEntity
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        // Add a variable to control the flashing state
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
             MitsubishiNexWayScreen1Even.hasButtonsClient(trackPosition, buttonDescriptor, (floorIndex, lift) -> {
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
-
-                LiftDirection pressedButtonDirection = blockEntity.getPressedButtonDirection();
-
-                ObjectObjectImmutablePair<LiftDirection, ObjectObjectImmutablePair<String, String>> liftDetails = ClientGetLiftDetails.getLiftDetails(world, lift, org.mtr.mod.Init.positionToBlockPos(lift.getCurrentFloor().getPosition()));
-                String floorNumber = liftDetails.right().left();
-                String currentFloorNumber = RenderLifts.getLiftDetails(world, lift, trackPosition).right().left();
-
-                final ObjectArraySet<LiftDirection> instructionDirections = lift.hasInstruction(floorIndex);
-
-                if (lift.getDoorValue() == 0) {
-                    blockEntity.lastUpActive = false;
-                    blockEntity.lastDownActive = false;
-                }
-
-                if (instructionDirections.isEmpty() && pressedButtonDirection != null && lift.getDoorValue() != 0 && floorNumber.equals(currentFloorNumber)) {
-                    switch (pressedButtonDirection) {
-                        case DOWN:
-                            if (flash) {
-                                downLanternLeft.activate();
-                                downLanternRight.activate();
-                            }
-                            if (!blockEntity.lastDownActive) {
-                                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                blockEntity.lastDownActive = true;
-                                blockEntity.lastUpActive = true;
-                            }
-                            break;
-                        case UP:
-                            if (flash) {
-                                upLanternLeft.activate();
-                                upLanternRight.activate();
-                            }
-                            if (!blockEntity.lastDownActive) {
-                                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                blockEntity.lastDownActive = true;
-                                blockEntity.lastUpActive = true;
-                            }
-                            break;
-                    }
-                }
-
-                instructionDirections.forEach(liftDirection -> {
-                    if (lift.getDoorValue() != 0 && floorNumber.equals(currentFloorNumber)) {
-                        if (liftDirection == NONE) {
-                            if (pressedButtonDirection != null) {
-                                switch (pressedButtonDirection) {
-                                    case DOWN:
-                                        if (flash) {
-                                            downLanternLeft.activate();
-                                            downLanternRight.activate();
-                                        }
-                                        if (!blockEntity.lastDownActive) {
-                                            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                            blockEntity.lastDownActive = true;
-                                            blockEntity.lastUpActive = true;
-                                        }
-                                        break;
-                                    case UP:
-                                        if (flash) {
-                                            upLanternLeft.activate();
-                                            upLanternRight.activate();
-                                        }
-                                        if (!blockEntity.lastDownActive) {
-                                            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                            blockEntity.lastDownActive = true;
-                                            blockEntity.lastUpActive = true;
-                                        }
-                                        break;
-                                }
-                            }
-                        } else {
-                            switch (liftDirection) {
-                                case DOWN:
-                                    downLanternLeft.activate();
-                                    downLanternRight.activate();
-                                    if (!blockEntity.lastDownActive) {
-                                        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                        blockEntity.lastDownActive = true;
-                                        blockEntity.lastUpActive = true;
-                                    }
-                                    break;
-                                case UP:
-                                    upLanternLeft.activate();
-                                    upLanternRight.activate();
-                                    if (!blockEntity.lastDownActive) {
-                                        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                        blockEntity.lastDownActive = true;
-                                        blockEntity.lastUpActive = true;
-                                    }
-                                    break;
-                            }
-                        }
-                    }
-
-                });
             });
+
+            final LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
+            if (state.downActive) {
+                downLanternLeft.activate();
+                downLanternRight.activate();
+            }
+            if (state.upActive) {
+                upLanternLeft.activate();
+                upLanternRight.activate();
+            }
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
+            }
         });
 
         sortedPositionsAndLifts.sort(Comparator.comparingInt(sortedPositionAndLift -> blockPos.getManhattanDistance(new Vector3i(sortedPositionAndLift.left().data))));

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayScreen1Segmented.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiNexWayScreen1Segmented.java
@@ -1,9 +1,7 @@
 package top.xfunny.mod.client.render;
 
 import org.mtr.core.data.Lift;
-import org.mtr.core.data.LiftDirection;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import org.mtr.mapping.holder.*;
 import org.mtr.mapping.mapper.BlockEntityRenderer;
@@ -12,7 +10,6 @@ import org.mtr.mapping.mapper.GraphicsHolder;
 import org.mtr.mapping.mapper.PlayerHelper;
 import org.mtr.mod.block.IBlock;
 import org.mtr.mod.data.IGui;
-import org.mtr.mod.render.RenderLifts;
 import org.mtr.mod.render.StoredMatrixTransformations;
 import top.xfunny.mod.Init;
 import top.xfunny.mod.block.MitsubishiNexWayScreen1SegmentedEven;
@@ -24,12 +21,10 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
-import top.xfunny.mod.util.ClientGetLiftDetails;
 
 import java.util.Comparator;
-
-import static org.mtr.core.data.LiftDirection.NONE;
 
 public class RenderMitsubishiNexWayScreen1Segmented<T extends LiftButtonsBase.BlockEntityBase> extends BlockEntityRenderer<T> implements DirectionHelper, IGui, IBlock {
     private static final int PRESSED_COLOR = 0xFFFEE1A9;
@@ -176,110 +171,27 @@ public class RenderMitsubishiNexWayScreen1Segmented<T extends LiftButtonsBase.Bl
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        // Add a variable to control the flashing state
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
             MitsubishiNexWayScreen1SegmentedEven.hasButtonsClient(trackPosition, buttonDescriptor, (floorIndex, lift) -> {
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
-
-                LiftDirection pressedButtonDirection = blockEntity.getPressedButtonDirection();
-
-                ObjectObjectImmutablePair<LiftDirection, ObjectObjectImmutablePair<String, String>> liftDetails = ClientGetLiftDetails.getLiftDetails(world, lift, org.mtr.mod.Init.positionToBlockPos(lift.getCurrentFloor().getPosition()));
-                String floorNumber = liftDetails.right().left();
-                String currentFloorNumber = RenderLifts.getLiftDetails(world, lift, trackPosition).right().left();
-
-                final ObjectArraySet<LiftDirection> instructionDirections = lift.hasInstruction(floorIndex);
-
-                if (lift.getDoorValue() == 0) {
-                    blockEntity.lastUpActive = false;
-                    blockEntity.lastDownActive = false;
-                }
-
-                if (instructionDirections.isEmpty() && pressedButtonDirection != null && lift.getDoorValue() != 0 && floorNumber.equals(currentFloorNumber)) {
-                    switch (pressedButtonDirection) {
-                        case DOWN:
-                            if (flash) {
-                                downLanternLeft.activate();
-                                downLanternRight.activate();
-                            }
-                            if (!blockEntity.lastDownActive) {
-                                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                blockEntity.lastDownActive = true;
-                                blockEntity.lastUpActive = true;
-                            }
-                            break;
-                        case UP:
-                            if (flash) {
-                                upLanternLeft.activate();
-                                upLanternRight.activate();
-                            }
-                            if (!blockEntity.lastDownActive) {
-                                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                blockEntity.lastDownActive = true;
-                                blockEntity.lastUpActive = true;
-                            }
-                            break;
-                    }
-                }
-
-                instructionDirections.forEach(liftDirection -> {
-                    if (lift.getDoorValue() != 0 && floorNumber.equals(currentFloorNumber)) {
-                        if (liftDirection == NONE) {
-                            if (pressedButtonDirection != null) {
-                                switch (pressedButtonDirection) {
-                                    case DOWN:
-                                        if (flash) {
-                                            downLanternLeft.activate();
-                                            downLanternRight.activate();
-                                        }
-                                        if (!blockEntity.lastDownActive) {
-                                            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                            blockEntity.lastDownActive = true;
-                                            blockEntity.lastUpActive = true;
-                                        }
-                                        break;
-                                    case UP:
-                                        if (flash) {
-                                            upLanternLeft.activate();
-                                            upLanternRight.activate();
-                                        }
-                                        if (!blockEntity.lastDownActive) {
-                                            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                            blockEntity.lastDownActive = true;
-                                            blockEntity.lastUpActive = true;
-                                        }
-                                        break;
-                                }
-                            }
-                        } else {
-                            switch (liftDirection) {
-                                case DOWN:
-                                    downLanternLeft.activate();
-                                    downLanternRight.activate();
-                                    if (!blockEntity.lastDownActive) {
-                                        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                        blockEntity.lastDownActive = true;
-                                        blockEntity.lastUpActive = true;
-                                    }
-                                    break;
-                                case UP:
-                                    upLanternLeft.activate();
-                                    upLanternRight.activate();
-                                    if (!blockEntity.lastDownActive) {
-                                        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                        blockEntity.lastDownActive = true;
-                                        blockEntity.lastUpActive = true;
-                                    }
-                                    break;
-                            }
-                        }
-                    }
-
-                });
             });
+
+            final LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
+            if (state.downActive) {
+                downLanternLeft.activate();
+                downLanternRight.activate();
+            }
+            if (state.upActive) {
+                upLanternLeft.activate();
+                upLanternRight.activate();
+            }
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
+            }
         });
 
         sortedPositionsAndLifts.sort(Comparator.comparingInt(sortedPositionAndLift -> blockPos.getManhattanDistance(new Vector3i(sortedPositionAndLift.left().data))));

--- a/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiRyodenScreen1.java
+++ b/fabric/src/main/java/top/xfunny/mod/client/render/RenderMitsubishiRyodenScreen1.java
@@ -1,9 +1,7 @@
 package top.xfunny.mod.client.render;
 
 import org.mtr.core.data.Lift;
-import org.mtr.core.data.LiftDirection;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import org.mtr.mapping.holder.*;
 import org.mtr.mapping.mapper.BlockEntityRenderer;
@@ -12,7 +10,6 @@ import org.mtr.mapping.mapper.GraphicsHolder;
 import org.mtr.mapping.mapper.PlayerHelper;
 import org.mtr.mod.block.IBlock;
 import org.mtr.mod.data.IGui;
-import org.mtr.mod.render.RenderLifts;
 import org.mtr.mod.render.StoredMatrixTransformations;
 import top.xfunny.mod.Init;
 import top.xfunny.mod.block.MitsubishiNexWayScreen1Even;
@@ -24,12 +21,10 @@ import top.xfunny.mod.client.view.view_group.FrameLayout;
 import top.xfunny.mod.client.view.view_group.LinearLayout;
 import top.xfunny.mod.item.YteGroupLiftButtonsLinker;
 import top.xfunny.mod.item.YteLiftButtonsLinker;
+import top.xfunny.mod.lift.policy.MitsubishiNexWayLanternPolicy;
 import top.xfunny.mod.packet.PacketLanternSoundInstruction;
-import top.xfunny.mod.util.ClientGetLiftDetails;
 
 import java.util.Comparator;
-
-import static org.mtr.core.data.LiftDirection.NONE;
 
 public class RenderMitsubishiRyodenScreen1<T extends LiftButtonsBase.BlockEntityBase> extends BlockEntityRenderer<T> implements DirectionHelper, IGui, IBlock {
     private static final int PRESSED_COLOR = 0xFFFEE1A9;
@@ -176,109 +171,27 @@ public class RenderMitsubishiRyodenScreen1<T extends LiftButtonsBase.BlockEntity
 
         final ObjectArrayList<ObjectObjectImmutablePair<BlockPos, Lift>> sortedPositionsAndLifts = new ObjectArrayList<>();
 
-        // Add a variable to control the flashing state
-        final boolean flash = (System.currentTimeMillis() % 1000) < 500;
-
         blockEntity.forEachTrackPosition(trackPosition -> {
             line.RenderLine(holdingLinker, trackPosition);
 
             MitsubishiNexWayScreen1Even.hasButtonsClient(trackPosition, buttonDescriptor, (floorIndex, lift) -> {
                 sortedPositionsAndLifts.add(new ObjectObjectImmutablePair<>(trackPosition, lift));
-
-                LiftDirection pressedButtonDirection = blockEntity.getPressedButtonDirection();
-
-                ObjectObjectImmutablePair<LiftDirection, ObjectObjectImmutablePair<String, String>> liftDetails = ClientGetLiftDetails.getLiftDetails(world, lift, org.mtr.mod.Init.positionToBlockPos(lift.getCurrentFloor().getPosition()));
-                String floorNumber = liftDetails.right().left();
-                String currentFloorNumber = RenderLifts.getLiftDetails(world, lift, trackPosition).right().left();
-
-                final ObjectArraySet<LiftDirection> instructionDirections = lift.hasInstruction(floorIndex);
-
-                if (lift.getDoorValue() == 0) {
-                    blockEntity.lastUpActive = false;
-                    blockEntity.lastDownActive = false;
-                }
-
-                if (instructionDirections.isEmpty() && pressedButtonDirection != null && lift.getDoorValue() != 0 && floorNumber.equals(currentFloorNumber)) {
-                    switch (pressedButtonDirection) {
-                        case DOWN:
-                            if (flash) {
-                                downLanternLeft.activate();
-                                downLanternRight.activate();
-                            }
-                            if (!blockEntity.lastDownActive) {
-                                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                blockEntity.lastDownActive = true;
-                                blockEntity.lastUpActive = true;
-                            }
-                            break;
-                        case UP:
-                            if (flash) {
-                                upLanternLeft.activate();
-                                upLanternRight.activate();
-                            }
-                            if (!blockEntity.lastDownActive) {
-                                InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                blockEntity.lastDownActive = true;
-                                blockEntity.lastUpActive = true;
-                            }
-                            break;
-                    }
-                }
-
-                instructionDirections.forEach(liftDirection -> {
-                    if (lift.getDoorValue() != 0 && floorNumber.equals(currentFloorNumber)) {
-                        if (liftDirection == NONE) {
-                            if (pressedButtonDirection != null) {
-                                switch (pressedButtonDirection) {
-                                    case DOWN:
-                                        if (flash) {
-                                            downLanternLeft.activate();
-                                            downLanternRight.activate();
-                                        }
-                                        if (!blockEntity.lastDownActive) {
-                                            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                            blockEntity.lastDownActive = true;
-                                            blockEntity.lastUpActive = true;
-                                        }
-                                        break;
-                                    case UP:
-                                        if (flash) {
-                                            upLanternLeft.activate();
-                                            upLanternRight.activate();
-                                        }
-                                        if (!blockEntity.lastDownActive) {
-                                            InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                            blockEntity.lastDownActive = true;
-                                            blockEntity.lastUpActive = true;
-                                        }
-                                        break;
-                                }
-                            }
-                        } else {
-                            switch (liftDirection) {
-                                case DOWN:
-                                    downLanternLeft.activate();
-                                    downLanternRight.activate();
-                                    if (!blockEntity.lastDownActive) {
-                                        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                        blockEntity.lastDownActive = true;
-                                        blockEntity.lastUpActive = true;
-                                    }
-                                    break;
-                                case UP:
-                                    upLanternLeft.activate();
-                                    upLanternRight.activate();
-                                    if (!blockEntity.lastDownActive) {
-                                        InitClient.REGISTRY_CLIENT.sendPacketToServer(new PacketLanternSoundInstruction(blockPos, "mitsubishi_nexway_lantern_1_down"));
-                                        blockEntity.lastDownActive = true;
-                                        blockEntity.lastUpActive = true;
-                                    }
-                                    break;
-                            }
-                        }
-                    }
-                });
             });
+
+            final LiftButtonsBase.LanternState state = blockEntity.getLanternState(
+                    trackPosition, MitsubishiNexWayLanternPolicy.INSTANCE);
+            if (state.downActive) {
+                downLanternLeft.activate();
+                downLanternRight.activate();
+            }
+            if (state.upActive) {
+                upLanternLeft.activate();
+                upLanternRight.activate();
+            }
+            if (state.justTriggered && state.soundCue != null) {
+                InitClient.REGISTRY_CLIENT.sendPacketToServer(
+                        new PacketLanternSoundInstruction(blockPos, state.soundCue));
+            }
         });
 
         sortedPositionsAndLifts.sort(Comparator.comparingInt(sortedPositionAndLift -> blockPos.getManhattanDistance(new Vector3i(sortedPositionAndLift.left().data))));

--- a/fabric/src/main/java/top/xfunny/mod/config/YteLiftConfigStore.java
+++ b/fabric/src/main/java/top/xfunny/mod/config/YteLiftConfigStore.java
@@ -1,5 +1,6 @@
 package top.xfunny.mod.config;
 
+import top.xfunny.mod.lift.LiftArrivalLanternTriggerMode;
 import top.xfunny.mod.lift.LiftDoorButtonLightMode;
 import top.xfunny.mod.lift.LiftFloorCancelMode;
 import top.xfunny.mod.lift.LiftMotionProfile;
@@ -25,6 +26,7 @@ public final class YteLiftConfigStore {
     private static final Map<Long, LiftDoorButtonLightMode> doorButtonLightModeMap = new ConcurrentHashMap<>();
     private static final Map<Long, LiftFloorCancelMode> floorCancelModeMap = new ConcurrentHashMap<>();
     private static final Map<Long, Boolean> floorCancelWhileMovingMap = new ConcurrentHashMap<>();
+    private static final Map<Long, LiftArrivalLanternTriggerMode> arrivalLanternTriggerModeMap = new ConcurrentHashMap<>();
     private static final Map<Long, String> liftNumberMap = new ConcurrentHashMap<>();
 
     private static final double DEFAULT_SPEED = 10.0;
@@ -63,6 +65,15 @@ public final class YteLiftConfigStore {
             double adoDistance, double levellingDistance, double levellingSpeed, LiftMotionProfile motionProfile,
             boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode, LiftFloorCancelMode floorCancelMode,
             boolean floorCancelWhileMoving) {
+        put(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, adoDistance, levellingDistance,
+                levellingSpeed, motionProfile, doorHoldEnabled, doorButtonLightMode, floorCancelMode,
+                floorCancelWhileMoving, LiftArrivalLanternTriggerMode.DECELERATION);
+    }
+
+    public static void put(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
+            double adoDistance, double levellingDistance, double levellingSpeed, LiftMotionProfile motionProfile,
+            boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode, LiftFloorCancelMode floorCancelMode,
+            boolean floorCancelWhileMoving, LiftArrivalLanternTriggerMode arrivalLanternTriggerMode) {
         speedMap.put(liftId, upSpeed);
         downSpeedMap.put(liftId, downSpeed);
         accelerationMap.put(liftId, upAcceleration);
@@ -75,6 +86,7 @@ public final class YteLiftConfigStore {
         doorButtonLightModeMap.put(liftId, doorButtonLightMode);
         floorCancelModeMap.put(liftId, floorCancelMode);
         floorCancelWhileMovingMap.put(liftId, floorCancelWhileMoving);
+        arrivalLanternTriggerModeMap.put(liftId, arrivalLanternTriggerMode);
     }
 
     public static double getSpeed(long liftId) {
@@ -119,6 +131,10 @@ public final class YteLiftConfigStore {
         return floorCancelWhileMovingMap.getOrDefault(liftId, false);
     }
 
+    public static LiftArrivalLanternTriggerMode getArrivalLanternTriggerMode(long liftId) {
+        return arrivalLanternTriggerModeMap.getOrDefault(liftId, LiftArrivalLanternTriggerMode.DECELERATION);
+    }
+
     /**
      * 电梯编号（备注别名，非 MTR 的 liftId）。
      * 未设置时返回空字符串。
@@ -148,6 +164,7 @@ public final class YteLiftConfigStore {
         doorButtonLightModeMap.remove(liftId);
         floorCancelModeMap.remove(liftId);
         floorCancelWhileMovingMap.remove(liftId);
+        arrivalLanternTriggerModeMap.remove(liftId);
         liftNumberMap.remove(liftId);
     }
 
@@ -164,6 +181,7 @@ public final class YteLiftConfigStore {
         doorButtonLightModeMap.clear();
         floorCancelModeMap.clear();
         floorCancelWhileMovingMap.clear();
+        arrivalLanternTriggerModeMap.clear();
         liftNumberMap.clear();
     }
 }

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternAssignmentProvider.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternAssignmentProvider.java
@@ -1,0 +1,9 @@
+package top.xfunny.mod.lift;
+
+@FunctionalInterface
+public interface LiftArrivalLanternAssignmentProvider {
+
+    LiftArrivalLanternAssignmentProvider NONE = (liftId, floor) -> LiftArrivalLanternGroupAssignment.NONE;
+
+    LiftArrivalLanternGroupAssignment getAssignment(long liftId, int floor);
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternContext.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternContext.java
@@ -1,0 +1,56 @@
+package top.xfunny.mod.lift;
+
+import org.mtr.core.data.LiftDirection;
+
+/** Immutable input supplied to a brand-specific arrival-lantern policy. */
+public final class LiftArrivalLanternContext {
+
+    private static final double SPEED_EPSILON = 0.000000001;
+
+    private final LiftDisplayState facts;
+    private final LiftArrivalLanternState arrivalState;
+    private final LiftArrivalLanternTriggerMode configuredTriggerMode;
+    private final int lanternFloor;
+    private final int floorDistance;
+    private final LiftDirection registeredCallDirection;
+    private final long callRegisteredMillis;
+    private final long currentMillis;
+    private final LiftArrivalLanternGroupAssignment groupAssignment;
+
+    public LiftArrivalLanternContext(LiftDisplayState facts, LiftArrivalLanternState arrivalState,
+            LiftArrivalLanternTriggerMode configuredTriggerMode, int lanternFloor, int floorDistance,
+            LiftDirection registeredCallDirection, long callRegisteredMillis, long currentMillis,
+            LiftArrivalLanternGroupAssignment groupAssignment) {
+        this.facts = facts;
+        this.arrivalState = arrivalState;
+        this.configuredTriggerMode = configuredTriggerMode;
+        this.lanternFloor = lanternFloor;
+        this.floorDistance = floorDistance;
+        this.registeredCallDirection = registeredCallDirection;
+        this.callRegisteredMillis = callRegisteredMillis;
+        this.currentMillis = currentMillis;
+        this.groupAssignment = groupAssignment == null
+                ? LiftArrivalLanternGroupAssignment.NONE : groupAssignment;
+    }
+
+    public LiftDisplayState getFacts() { return facts; }
+    public LiftArrivalLanternState getArrivalState() { return arrivalState; }
+    public LiftArrivalLanternTriggerMode getConfiguredTriggerMode() { return configuredTriggerMode; }
+    public int getLanternFloor() { return lanternFloor; }
+    public int getFloorDistance() { return floorDistance; }
+    public LiftDirection getRegisteredCallDirection() { return registeredCallDirection; }
+    public long getCallRegisteredMillis() { return callRegisteredMillis; }
+    public long getCurrentMillis() { return currentMillis; }
+    public LiftArrivalLanternGroupAssignment getGroupAssignment() { return groupAssignment; }
+
+    public long getMillisSinceCallRegistration() {
+        return callRegisteredMillis <= 0 ? Long.MAX_VALUE : Math.max(currentMillis - callRegisteredMillis, 0);
+    }
+
+    /** Estimate based on remaining rail distance and current absolute speed. */
+    public long estimateMillisToTarget() {
+        final double absoluteSpeed = Math.abs(facts.getSpeed());
+        return absoluteSpeed <= SPEED_EPSILON || !Double.isFinite(facts.getDistanceToTarget())
+                ? Long.MAX_VALUE : Math.max(Math.round(facts.getDistanceToTarget() / absoluteSpeed), 0);
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternDecision.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternDecision.java
@@ -1,0 +1,52 @@
+package top.xfunny.mod.lift;
+
+import org.mtr.core.data.LiftDirection;
+
+/** Policy output consumed by the common lantern renderer adapter. */
+public final class LiftArrivalLanternDecision {
+
+    private static final LiftArrivalLanternDecision INACTIVE = new LiftArrivalLanternDecision(
+            false, LiftDirection.NONE, LiftArrivalLanternDisplayPhase.IDLE,
+            LiftArrivalLanternFlashPattern.OFF, null, 0, 0);
+
+    private final boolean active;
+    private final LiftDirection direction;
+    private final LiftArrivalLanternDisplayPhase phase;
+    private final LiftArrivalLanternFlashPattern flashPattern;
+    private final String soundCue;
+    private final long eventSequence;
+    private final long phaseStartMillis;
+
+    private LiftArrivalLanternDecision(boolean active, LiftDirection direction,
+            LiftArrivalLanternDisplayPhase phase, LiftArrivalLanternFlashPattern flashPattern,
+            String soundCue, long eventSequence, long phaseStartMillis) {
+        this.active = active;
+        this.direction = direction;
+        this.phase = phase;
+        this.flashPattern = flashPattern;
+        this.soundCue = soundCue;
+        this.eventSequence = eventSequence;
+        this.phaseStartMillis = phaseStartMillis;
+    }
+
+    public static LiftArrivalLanternDecision inactive() {
+        return INACTIVE;
+    }
+
+    public static LiftArrivalLanternDecision active(LiftDirection direction,
+            LiftArrivalLanternDisplayPhase phase, LiftArrivalLanternFlashPattern flashPattern,
+            String soundCue, long eventSequence, long phaseStartMillis) {
+        return direction == null || direction == LiftDirection.NONE ? INACTIVE
+                : new LiftArrivalLanternDecision(true, direction, phase,
+                flashPattern == null ? LiftArrivalLanternFlashPattern.STEADY : flashPattern,
+                soundCue, eventSequence, phaseStartMillis);
+    }
+
+    public boolean isActive() { return active; }
+    public LiftDirection getDirection() { return direction; }
+    public LiftArrivalLanternDisplayPhase getPhase() { return phase; }
+    public LiftArrivalLanternFlashPattern getFlashPattern() { return flashPattern; }
+    public String getSoundCue() { return soundCue; }
+    public long getEventSequence() { return eventSequence; }
+    public long getPhaseStartMillis() { return phaseStartMillis; }
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternDisplayPhase.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternDisplayPhase.java
@@ -1,0 +1,9 @@
+package top.xfunny.mod.lift;
+
+public enum LiftArrivalLanternDisplayPhase {
+    IDLE,
+    CALL_REGISTERED,
+    APPROACHING,
+    ARRIVED,
+    CLOSING
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternFlashPattern.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternFlashPattern.java
@@ -1,0 +1,41 @@
+package top.xfunny.mod.lift;
+
+/** A reusable light pattern; durations are milliseconds. */
+public final class LiftArrivalLanternFlashPattern {
+
+    public static final LiftArrivalLanternFlashPattern OFF = new LiftArrivalLanternFlashPattern(0, Long.MAX_VALUE);
+    public static final LiftArrivalLanternFlashPattern STEADY = new LiftArrivalLanternFlashPattern(Long.MAX_VALUE, 0);
+
+    private final long onMillis;
+    private final long offMillis;
+
+    private LiftArrivalLanternFlashPattern(long onMillis, long offMillis) {
+        this.onMillis = Math.max(onMillis, 0);
+        this.offMillis = Math.max(offMillis, 0);
+    }
+
+    public static LiftArrivalLanternFlashPattern flashing(long onMillis, long offMillis) {
+        return onMillis <= 0 ? OFF : offMillis <= 0 ? STEADY
+                : new LiftArrivalLanternFlashPattern(onMillis, offMillis);
+    }
+
+    public boolean isLit(long currentMillis, long phaseStartMillis) {
+        if (this == OFF || onMillis == 0) {
+            return false;
+        }
+        if (this == STEADY || offMillis == 0 || onMillis == Long.MAX_VALUE) {
+            return true;
+        }
+        final long cycleMillis = onMillis + offMillis;
+        final long elapsedMillis = Math.max(currentMillis - phaseStartMillis, 0);
+        return elapsedMillis % cycleMillis < onMillis;
+    }
+
+    public long getOnMillis() {
+        return onMillis;
+    }
+
+    public long getOffMillis() {
+        return offMillis;
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternGroupAssignment.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternGroupAssignment.java
@@ -1,0 +1,41 @@
+package top.xfunny.mod.lift;
+
+import org.mtr.core.data.LiftDirection;
+
+/**
+ * Reserved AIL/group-control assignment input. A future dispatcher can publish
+ * the selected lift, direction, assignment time and pre-announcement cue.
+ */
+public final class LiftArrivalLanternGroupAssignment {
+
+    public static final LiftArrivalLanternGroupAssignment NONE = new LiftArrivalLanternGroupAssignment(
+            false, 0, -1, LiftDirection.NONE, 0, null);
+
+    private final boolean assigned;
+    private final long assignedLiftId;
+    private final int floor;
+    private final LiftDirection direction;
+    private final long assignedMillis;
+    private final String preAnnouncementCue;
+
+    public LiftArrivalLanternGroupAssignment(boolean assigned, long assignedLiftId, int floor,
+            LiftDirection direction, long assignedMillis, String preAnnouncementCue) {
+        this.assigned = assigned;
+        this.assignedLiftId = assignedLiftId;
+        this.floor = floor;
+        this.direction = direction == null ? LiftDirection.NONE : direction;
+        this.assignedMillis = assignedMillis;
+        this.preAnnouncementCue = preAnnouncementCue;
+    }
+
+    public boolean isAssigned() { return assigned; }
+    public long getAssignedLiftId() { return assignedLiftId; }
+    public int getFloor() { return floor; }
+    public LiftDirection getDirection() { return direction; }
+    public long getAssignedMillis() { return assignedMillis; }
+    public String getPreAnnouncementCue() { return preAnnouncementCue; }
+
+    public boolean isAssignedTo(long liftId, int lanternFloor) {
+        return assigned && assignedLiftId == liftId && floor == lanternFloor;
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternPolicy.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternPolicy.java
@@ -1,0 +1,19 @@
+package top.xfunny.mod.lift;
+
+@FunctionalInterface
+public interface LiftArrivalLanternPolicy {
+
+    LiftArrivalLanternPolicy DEFAULT = context -> {
+        final LiftArrivalLanternState state = context.getArrivalState();
+        if (!state.isActiveForFloor(context.getLanternFloor())) {
+            return LiftArrivalLanternDecision.inactive();
+        }
+        return LiftArrivalLanternDecision.active(state.getDirection(),
+                state.isArrived() ? LiftArrivalLanternDisplayPhase.ARRIVED
+                        : LiftArrivalLanternDisplayPhase.APPROACHING,
+                LiftArrivalLanternFlashPattern.STEADY, null,
+                state.getTriggerSequence(), state.getTriggerStartedMillis());
+    };
+
+    LiftArrivalLanternDecision evaluate(LiftArrivalLanternContext context);
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternSignal.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternSignal.java
@@ -1,0 +1,12 @@
+package top.xfunny.mod.lift;
+
+/** Extensible event vocabulary for brand-specific arrival-lantern policies. */
+public enum LiftArrivalLanternSignal {
+    NONE,
+    CALL_REGISTERED,
+    APPROACH_STARTED,
+    DECELERATION_STARTED,
+    DOOR_OPENING_STARTED,
+    DOOR_CLOSING_STARTED,
+    DOOR_CLOSED
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternState.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternState.java
@@ -1,0 +1,187 @@
+package top.xfunny.mod.lift;
+
+import org.mtr.core.data.LiftDirection;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Client-side, per-lift arrival-lantern latch. It separates the short trigger
+ * edge (deceleration or door opening) from the full approach/door cycle so
+ * renderers do not depend on lift instructions that are removed at arrival.
+ */
+public final class LiftArrivalLanternState {
+
+    private static final double DOOR_OPEN_EPSILON = 0.000001;
+    private static final Map<Long, LiftArrivalLanternState> STATES = new ConcurrentHashMap<>();
+
+    private final long liftId;
+    private int armedFloor = -1;
+    private int triggeredFloor = -1;
+    private LiftDirection armedDirection = LiftDirection.NONE;
+    private LiftDirection direction = LiftDirection.NONE;
+    private boolean active;
+    private boolean arrived;
+    private boolean doorOpened;
+    private long triggerSequence;
+    private long triggerStartedMillis;
+    private LiftArrivalLanternSignal triggerSignal = LiftArrivalLanternSignal.NONE;
+
+    private LiftArrivalLanternState(long liftId) {
+        this.liftId = liftId;
+    }
+
+    public static LiftArrivalLanternState get(long liftId) {
+        return STATES.computeIfAbsent(liftId, LiftArrivalLanternState::new);
+    }
+
+    public static void clear() {
+        STATES.clear();
+    }
+
+    public void update(LiftDisplayState facts, LiftArrivalLanternTriggerMode triggerMode) {
+        final boolean doorOpen = facts.getDoorValue() > DOOR_OPEN_EPSILON;
+        final LiftDisplayDirectionState directionState = LiftDisplayDirectionState.get(liftId);
+
+        if (active) {
+            if (doorOpen) {
+                arrived = true;
+                doorOpened = true;
+            }
+            // The announced direction is allowed to settle during approach, but
+            // once door movement starts it must remain latched for the complete
+            // open/close cycle. Later calls belong to the following journey.
+            if (!doorOpened) {
+                final LiftDirection resolvedDirection = resolveDirection(facts, directionState, triggeredFloor);
+                if (resolvedDirection != LiftDirection.NONE) {
+                    direction = resolvedDirection;
+                }
+            }
+
+            final boolean doorCycleFinished = doorOpened && !doorOpen && !facts.isDoorCycle();
+            final boolean targetCancelledBeforeArrival = !doorOpened && !facts.isDoorCycle()
+                    && facts.getTargetFloor() != triggeredFloor;
+            if (doorCycleFinished || targetCancelledBeforeArrival) {
+                resetLatch();
+            }
+        }
+
+        if (!active) {
+            updateArmedTarget(facts, directionState, doorOpen);
+
+            final LiftDirection sameFloorDirection = resolveSameFloorDirection(directionState);
+            final boolean sameFloorDoorTrigger = doorOpen && facts.getExactFloor() >= 0
+                    && sameFloorDirection != LiftDirection.NONE;
+            final boolean decelerationTrigger = triggerMode == LiftArrivalLanternTriggerMode.DECELERATION
+                    && armedFloor >= 0 && facts.getTargetFloor() == armedFloor
+                    && facts.isMoving() && facts.isDecelerating();
+            final boolean retainedArrivalAtExactFloor = facts.getExactFloor() >= 0
+                    && directionState.arrivalFloor == facts.getExactFloor();
+            final boolean doorTrigger = triggerMode == LiftArrivalLanternTriggerMode.DOOR_OPEN
+                    && doorOpen && (armedFloor >= 0 || retainedArrivalAtExactFloor);
+
+            if (decelerationTrigger || sameFloorDoorTrigger || doorTrigger) {
+                final int triggerFloor = sameFloorDoorTrigger || retainedArrivalAtExactFloor
+                        ? facts.getExactFloor() : armedFloor;
+                final LiftDirection triggerDirection = resolveDirection(facts, directionState, triggerFloor);
+                if (triggerFloor >= 0 && triggerDirection != LiftDirection.NONE) {
+                    active = true;
+                    arrived = doorOpen;
+                    doorOpened = doorOpen;
+                    triggeredFloor = triggerFloor;
+                    direction = triggerDirection;
+                    triggerSequence++;
+                    triggerStartedMillis = System.currentTimeMillis();
+                    triggerSignal = decelerationTrigger
+                            ? LiftArrivalLanternSignal.DECELERATION_STARTED
+                            : LiftArrivalLanternSignal.DOOR_OPENING_STARTED;
+                }
+            }
+        }
+
+    }
+
+    private void updateArmedTarget(LiftDisplayState facts, LiftDisplayDirectionState directionState, boolean doorOpen) {
+        final int targetFloor = facts.getTargetFloor();
+        if (targetFloor >= 0) {
+            if (armedFloor < 0 || targetFloor == armedFloor || !facts.isDoorCycle()) {
+                armedFloor = targetFloor;
+                final LiftDirection resolvedDirection = resolveDirection(facts, directionState, armedFloor);
+                if (resolvedDirection != LiftDirection.NONE) {
+                    armedDirection = resolvedDirection;
+                }
+            }
+        } else if (!facts.isDoorCycle() && !doorOpen) {
+            armedFloor = -1;
+            armedDirection = LiftDirection.NONE;
+        }
+    }
+
+    private LiftDirection resolveDirection(LiftDisplayState facts,
+            LiftDisplayDirectionState directionState, int floor) {
+        if (floor >= 0 && facts.getExactFloor() == floor) {
+            final LiftDirection sameFloorDirection = resolveSameFloorDirection(directionState);
+            if (sameFloorDirection != LiftDirection.NONE) {
+                return sameFloorDirection;
+            }
+        }
+        if (facts.getPlannedArrivalDirection() != LiftDirection.NONE) {
+            return facts.getPlannedArrivalDirection();
+        }
+        if (directionState.arrivalFloor == floor && directionState.arrivalDirection != LiftDirection.NONE) {
+            return directionState.arrivalDirection;
+        }
+        if (facts.getLatchedDirection() != LiftDirection.NONE) {
+            return facts.getLatchedDirection();
+        }
+        if (facts.getMovementDirection() != LiftDirection.NONE) {
+            return facts.getMovementDirection();
+        }
+        if (facts.getTargetDirection() != LiftDirection.NONE) {
+            return facts.getTargetDirection();
+        }
+        return armedDirection;
+    }
+
+    private static LiftDirection resolveSameFloorDirection(LiftDisplayDirectionState directionState) {
+        if (directionState.sameFloorCallDirection != LiftDirection.NONE) {
+            return directionState.sameFloorCallDirection;
+        }
+        return directionState.deferredSameFloorCallDirection;
+    }
+
+    private void resetLatch() {
+        active = false;
+        arrived = false;
+        doorOpened = false;
+        triggeredFloor = -1;
+        direction = LiftDirection.NONE;
+        armedFloor = -1;
+        armedDirection = LiftDirection.NONE;
+        triggerSignal = LiftArrivalLanternSignal.NONE;
+    }
+
+    public boolean isActiveForFloor(int floor) {
+        return active && triggeredFloor == floor;
+    }
+
+    public boolean isArrived() {
+        return arrived;
+    }
+
+    public LiftDirection getDirection() {
+        return direction;
+    }
+
+    public long getTriggerSequence() {
+        return triggerSequence;
+    }
+
+    public long getTriggerStartedMillis() {
+        return triggerStartedMillis;
+    }
+
+    public LiftArrivalLanternSignal getTriggerSignal() {
+        return triggerSignal;
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternTriggerMode.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftArrivalLanternTriggerMode.java
@@ -1,0 +1,29 @@
+package top.xfunny.mod.lift;
+
+public enum LiftArrivalLanternTriggerMode {
+    DECELERATION("gui.yte.lift_arrival_lantern_trigger_deceleration"),
+    DOOR_OPEN("gui.yte.lift_arrival_lantern_trigger_door_open");
+
+    private final String translationKey;
+
+    LiftArrivalLanternTriggerMode(String translationKey) {
+        this.translationKey = translationKey;
+    }
+
+    public String getTranslationKey() {
+        return translationKey;
+    }
+
+    public LiftArrivalLanternTriggerMode next() {
+        final LiftArrivalLanternTriggerMode[] values = values();
+        return values[(ordinal() + 1) % values.length];
+    }
+
+    public static LiftArrivalLanternTriggerMode fromSerializedName(String value) {
+        try {
+            return value == null ? DECELERATION : valueOf(value);
+        } catch (IllegalArgumentException ignored) {
+            return DECELERATION;
+        }
+    }
+}

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftDisplayDirectionState.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftDisplayDirectionState.java
@@ -31,6 +31,11 @@ public final class LiftDisplayDirectionState {
         return STATES.computeIfAbsent(liftId, ignored -> new LiftDisplayDirectionState());
     }
 
+    public static synchronized void clear() {
+        STATES.clear();
+        PENDING_SAME_FLOOR_CALLS.clear();
+    }
+
     public static synchronized void registerPendingSameFloorCall(Set<Long> candidateLiftIds, LiftDirection direction) {
         if (candidateLiftIds.isEmpty() || direction == LiftDirection.NONE) {
             return;

--- a/fabric/src/main/java/top/xfunny/mod/lift/LiftDisplayState.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/LiftDisplayState.java
@@ -16,14 +16,19 @@ public final class LiftDisplayState {
     private final long liftId;
     private LiftDirection movementDirection = LiftDirection.NONE;
     private LiftDirection targetDirection = LiftDirection.NONE;
+    private LiftDirection plannedArrivalDirection = LiftDirection.NONE;
     private boolean moving;
     private boolean decelerating;
     private boolean levelling;
     private boolean doorCycle;
     private boolean idle = true;
     private int displayedFloor = -1;
+    private int exactFloor = -1;
     private int targetFloor = -1;
     private double speed;
+    private double doorValue;
+    private boolean doorOpening;
+    private boolean doorClosing;
     private double distanceToTarget = Double.POSITIVE_INFINITY;
     private long stoppingCoolDown;
     private double previousAbsoluteSpeed;
@@ -36,22 +41,32 @@ public final class LiftDisplayState {
         return STATES.computeIfAbsent(liftId, LiftDisplayState::new);
     }
 
+    public static void clear() {
+        STATES.clear();
+    }
+
     public void update(LiftDirection movementDirection, LiftDirection targetDirection,
+            LiftDirection plannedArrivalDirection,
             boolean moving, boolean levelling, boolean doorCycle, boolean idle,
-            int displayedFloor, int targetFloor, double speed,
+            int displayedFloor, int exactFloor, int targetFloor, double speed, double doorValue,
             double distanceToTarget, long stoppingCoolDown) {
         final double absoluteSpeed = Math.abs(speed);
         decelerating = moving && previousAbsoluteSpeed > 0 && absoluteSpeed + 0.000000001 < previousAbsoluteSpeed;
         previousAbsoluteSpeed = absoluteSpeed;
+        doorOpening = doorValue > this.doorValue + 0.000001;
+        doorClosing = doorValue + 0.000001 < this.doorValue;
         this.movementDirection = movementDirection;
         this.targetDirection = targetDirection;
+        this.plannedArrivalDirection = plannedArrivalDirection;
         this.moving = moving;
         this.levelling = levelling;
         this.doorCycle = doorCycle;
         this.idle = idle;
         this.displayedFloor = displayedFloor;
+        this.exactFloor = exactFloor;
         this.targetFloor = targetFloor;
         this.speed = speed;
+        this.doorValue = doorValue;
         this.distanceToTarget = distanceToTarget;
         this.stoppingCoolDown = stoppingCoolDown;
     }
@@ -59,14 +74,19 @@ public final class LiftDisplayState {
     public long getLiftId() { return liftId; }
     public LiftDirection getMovementDirection() { return movementDirection; }
     public LiftDirection getTargetDirection() { return targetDirection; }
+    public LiftDirection getPlannedArrivalDirection() { return plannedArrivalDirection; }
     public boolean isMoving() { return moving; }
     public boolean isDecelerating() { return decelerating; }
     public boolean isLevelling() { return levelling; }
     public boolean isDoorCycle() { return doorCycle; }
     public boolean isIdle() { return idle; }
     public int getDisplayedFloor() { return displayedFloor; }
+    public int getExactFloor() { return exactFloor; }
     public int getTargetFloor() { return targetFloor; }
     public double getSpeed() { return speed; }
+    public double getDoorValue() { return doorValue; }
+    public boolean isDoorOpening() { return doorOpening; }
+    public boolean isDoorClosing() { return doorClosing; }
     public double getDistanceToTarget() { return distanceToTarget; }
     public long getStoppingCoolDown() { return stoppingCoolDown; }
 

--- a/fabric/src/main/java/top/xfunny/mod/lift/policy/MitsubishiNexWayLanternPolicy.java
+++ b/fabric/src/main/java/top/xfunny/mod/lift/policy/MitsubishiNexWayLanternPolicy.java
@@ -1,0 +1,119 @@
+package top.xfunny.mod.lift.policy;
+
+import org.mtr.core.data.LiftDirection;
+import top.xfunny.mod.lift.LiftArrivalLanternContext;
+import top.xfunny.mod.lift.LiftArrivalLanternDecision;
+import top.xfunny.mod.lift.LiftArrivalLanternDisplayPhase;
+import top.xfunny.mod.lift.LiftArrivalLanternFlashPattern;
+import top.xfunny.mod.lift.LiftArrivalLanternPolicy;
+import top.xfunny.mod.lift.LiftArrivalLanternState;
+import top.xfunny.mod.lift.LiftDisplayState;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Mitsubishi NexWay/Ryoden non-AIL arrival-lantern behavior. */
+public final class MitsubishiNexWayLanternPolicy implements LiftArrivalLanternPolicy {
+
+    public static final MitsubishiNexWayLanternPolicy INSTANCE = new MitsubishiNexWayLanternPolicy();
+
+    private static final LiftArrivalLanternFlashPattern SLOW_FLASH =
+            LiftArrivalLanternFlashPattern.flashing(700, 400);
+    private static final LiftArrivalLanternFlashPattern FAST_FLASH =
+            LiftArrivalLanternFlashPattern.flashing(400, 300);
+
+    private final Map<Long, Integer> approachFloors = new ConcurrentHashMap<>();
+    private final Map<Long, Long> approachStartMillis = new ConcurrentHashMap<>();
+    private final Map<Long, Long> doorStartMillis = new ConcurrentHashMap<>();
+
+    private MitsubishiNexWayLanternPolicy() {
+    }
+
+    public void clear() {
+        approachFloors.clear();
+        approachStartMillis.clear();
+        doorStartMillis.clear();
+    }
+
+    @Override
+    public LiftArrivalLanternDecision evaluate(LiftArrivalLanternContext context) {
+        final LiftDisplayState facts = context.getFacts();
+        final LiftArrivalLanternState arrivalState = context.getArrivalState();
+        final long liftId = facts.getLiftId();
+        final int lanternFloor = context.getLanternFloor();
+
+        // AIL is intentionally not implemented yet. The assigned lift and its
+        // pre-announcement data are available through context.getGroupAssignment().
+
+        final boolean displayedTargetAndDecelerating = facts.getTargetFloor() == lanternFloor
+                && facts.getDisplayedFloor() == lanternFloor && facts.isDecelerating();
+        if (displayedTargetAndDecelerating) {
+            final Integer previousApproachFloor = approachFloors.put(liftId, lanternFloor);
+            if (previousApproachFloor == null || previousApproachFloor != lanternFloor) {
+                approachStartMillis.put(liftId, context.getCurrentMillis());
+            }
+            approachStartMillis.putIfAbsent(liftId, context.getCurrentMillis());
+        }
+        final boolean approachLatched = approachFloors.getOrDefault(liftId, -1) == lanternFloor
+                && (facts.getTargetFloor() == lanternFloor || arrivalState.isActiveForFloor(lanternFloor));
+        final boolean activeDoorCycleAtLantern = facts.getDoorValue() > 0
+                && arrivalState.isActiveForFloor(lanternFloor);
+        if (!approachLatched && !activeDoorCycleAtLantern) {
+            clearFinishedCycle(facts, arrivalState, liftId);
+            return LiftArrivalLanternDecision.inactive();
+        }
+
+        LiftDirection direction = activeDoorCycleAtLantern
+                ? arrivalState.getDirection() : facts.getPlannedArrivalDirection();
+        if (direction == LiftDirection.NONE) {
+            direction = arrivalState.getDirection();
+        }
+        if (direction == LiftDirection.NONE) {
+            direction = facts.getPlannedArrivalDirection();
+        }
+        if (direction == LiftDirection.NONE) {
+            return LiftArrivalLanternDecision.inactive();
+        }
+
+        final String soundCue = direction == LiftDirection.UP
+                ? "mitsubishi_nexway_lantern_1_up"
+                : "mitsubishi_nexway_lantern_1_down";
+
+        // Keep flashing through opening, fully open and closing; extinguish only
+        // after the door has reached the fully closed value.
+        if (arrivalState.isArrived() && facts.getDoorValue() <= 0) {
+            return LiftArrivalLanternDecision.inactive();
+        }
+
+        if (facts.getDoorValue() > 0) {
+            // isDoorOpening() remains true throughout door movement, so resetting
+            // this timestamp every frame would leave the flash permanently on.
+            doorStartMillis.putIfAbsent(liftId, context.getCurrentMillis());
+            final long eventSequence = approachStartMillis.getOrDefault(
+                    liftId, arrivalState.getTriggerSequence());
+            return LiftArrivalLanternDecision.active(direction,
+                    LiftArrivalLanternDisplayPhase.ARRIVED, FAST_FLASH, soundCue,
+                    eventSequence,
+                    doorStartMillis.getOrDefault(liftId, context.getCurrentMillis()));
+        }
+
+        if (approachLatched) {
+            return LiftArrivalLanternDecision.active(direction,
+                    LiftArrivalLanternDisplayPhase.APPROACHING, SLOW_FLASH, soundCue,
+                    approachStartMillis.getOrDefault(liftId, context.getCurrentMillis()),
+                    approachStartMillis.getOrDefault(liftId, context.getCurrentMillis()));
+        }
+
+        return LiftArrivalLanternDecision.inactive();
+    }
+
+    private void clearFinishedCycle(LiftDisplayState facts, LiftArrivalLanternState arrivalState, long liftId) {
+        final Integer approachFloor = approachFloors.get(liftId);
+        if (!facts.isDoorCycle() && (approachFloor == null
+                || !arrivalState.isActiveForFloor(approachFloor) && facts.getTargetFloor() != approachFloor)) {
+            approachFloors.remove(liftId);
+            approachStartMillis.remove(liftId);
+            doorStartMillis.remove(liftId);
+        }
+    }
+}

--- a/fabric/src/main/resources/assets/yte/lang/en_us.json
+++ b/fabric/src/main/resources/assets/yte/lang/en_us.json
@@ -443,6 +443,8 @@
   "gui.yte.lift_door_button_light_automatic": "Door button light: Follow door operation",
   "gui.yte.lift_floor_cancel_double_click": "Cancel selected floor: Double-click",
   "gui.yte.lift_floor_cancel_long_press": "Cancel selected floor: Long press",
+  "gui.yte.lift_arrival_lantern_trigger_deceleration": "Arrival lantern trigger: Deceleration",
+  "gui.yte.lift_arrival_lantern_trigger_door_open": "Arrival lantern trigger: Door opening",
   "gui.yte.lift_hold_open": "HOLD",
   "gui.yte.lift_number": "Lift Number",
   "gui.yte.lift_tab_base": "Base",

--- a/fabric/src/main/resources/assets/yte/lang/ja_jp.json
+++ b/fabric/src/main/resources/assets/yte/lang/ja_jp.json
@@ -438,6 +438,8 @@
   "gui.yte.lift_door_button_light_automatic": "ドアボタン点灯：ドア動作連動",
   "gui.yte.lift_floor_cancel_double_click": "行先階の取消：ダブルクリック",
   "gui.yte.lift_floor_cancel_long_press": "行先階の取消：長押し",
+  "gui.yte.lift_arrival_lantern_trigger_deceleration": "到着灯点灯：減速時",
+  "gui.yte.lift_arrival_lantern_trigger_door_open": "到着灯点灯：戸開始時",
   "gui.yte.lift_hold_open": "開延長",
   "gui.yte.lift_number": "バンク内号機番号",
   "gui.yte.lift_tab_base": "基本設定",

--- a/fabric/src/main/resources/assets/yte/lang/zh_cn.json
+++ b/fabric/src/main/resources/assets/yte/lang/zh_cn.json
@@ -438,6 +438,8 @@
   "gui.yte.lift_door_button_light_automatic": "开关门按钮灯光：跟随门动作",
   "gui.yte.lift_floor_cancel_double_click": "取消已选楼层：双击",
   "gui.yte.lift_floor_cancel_long_press": "取消已选楼层：长按",
+  "gui.yte.lift_arrival_lantern_trigger_deceleration": "到站灯触发：减速时",
+  "gui.yte.lift_arrival_lantern_trigger_door_open": "到站灯触发：开门时",
   "gui.yte.lift_hold_open": "延时关门",
   "gui.yte.lift_number": "电梯编号",
   "gui.yte.lift_tab_base": "基础",

--- a/fabric/src/main/resources/assets/yte/lang/zh_hk.json
+++ b/fabric/src/main/resources/assets/yte/lang/zh_hk.json
@@ -438,6 +438,8 @@
   "gui.yte.lift_door_button_light_automatic": "開關門掣燈：跟住門嘅動作",
   "gui.yte.lift_floor_cancel_double_click": "取消已選樓層：雙擊",
   "gui.yte.lift_floor_cancel_long_press": "取消已選樓層：長撳",
+  "gui.yte.lift_arrival_lantern_trigger_deceleration": "到站燈觸發：減速時",
+  "gui.yte.lift_arrival_lantern_trigger_door_open": "到站燈觸發：開門時",
   "gui.yte.lift_hold_open": "延遲關門",
   "gui.yte.lift_number": "升降機編號",
   "gui.yte.lift_tab_base": "Base",

--- a/forge/src/main/java/top/xfunny/core/data/YteData.java
+++ b/forge/src/main/java/top/xfunny/core/data/YteData.java
@@ -18,7 +18,7 @@ public abstract class YteData {
                         config.getUpAcceleration(), config.getDownAcceleration(), config.getAdoDistance(),
                         config.getLevellingDistance(), config.getLevellingSpeed(), config.getMotionProfile(),
                         config.isDoorHoldEnabled(), config.getDoorButtonLightMode(), config.getFloorCancelMode(),
-                        config.isFloorCancelWhileMovingAllowed());
+                        config.isFloorCancelWhileMovingAllowed(), config.getArrivalLanternTriggerMode());
                 top.xfunny.mod.config.YteLiftConfigStore.setLiftNumber(config.getId(), config.getLiftNumber());
             });
         } catch (Exception e) {

--- a/forge/src/main/java/top/xfunny/core/data/YteLiftConfig.java
+++ b/forge/src/main/java/top/xfunny/core/data/YteLiftConfig.java
@@ -2,6 +2,7 @@ package top.xfunny.core.data;
 
 import org.mtr.core.serializer.ReaderBase;
 import top.xfunny.core.generated.data.YteLiftConfigSchema;
+import top.xfunny.mod.lift.LiftArrivalLanternTriggerMode;
 import top.xfunny.mod.lift.LiftDoorButtonLightMode;
 import top.xfunny.mod.lift.LiftFloorCancelMode;
 import top.xfunny.mod.lift.LiftMotionProfile;
@@ -34,16 +35,29 @@ public class YteLiftConfig extends YteLiftConfigSchema {
             LiftMotionProfile motionProfile, boolean doorHoldEnabled) {
         this(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
                 adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
-                LiftDoorButtonLightMode.MOMENTARY, LiftFloorCancelMode.DOUBLE_CLICK, false, "");
+                LiftDoorButtonLightMode.MOMENTARY, LiftFloorCancelMode.DOUBLE_CLICK, false,
+                LiftArrivalLanternTriggerMode.DECELERATION, "");
     }
 
     public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             LiftMotionProfile motionProfile, boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode,
             LiftFloorCancelMode floorCancelMode, boolean floorCancelWhileMoving, String liftNumber) {
+        this(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                doorButtonLightMode, floorCancelMode, floorCancelWhileMoving,
+                LiftArrivalLanternTriggerMode.DECELERATION, liftNumber);
+    }
+
+    public YteLiftConfig(long liftId, double upSpeed, double downSpeed, double upAcceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            LiftMotionProfile motionProfile, boolean doorHoldEnabled, LiftDoorButtonLightMode doorButtonLightMode,
+            LiftFloorCancelMode floorCancelMode, boolean floorCancelWhileMoving,
+            LiftArrivalLanternTriggerMode arrivalLanternTriggerMode, String liftNumber) {
         super(liftId, upSpeed, downSpeed, upAcceleration, downAcceleration, directionParametersLinked,
                 adoDistance, levellingDistance, levellingSpeed, motionProfile.name(), doorHoldEnabled,
-                doorButtonLightMode.name(), floorCancelMode.name(), floorCancelWhileMoving, liftNumber);
+                doorButtonLightMode.name(), floorCancelMode.name(), floorCancelWhileMoving,
+                arrivalLanternTriggerMode.name(), liftNumber);
     }
 
     public YteLiftConfig(ReaderBase readerBase) {
@@ -88,6 +102,10 @@ public class YteLiftConfig extends YteLiftConfigSchema {
 
     public boolean isFloorCancelWhileMovingAllowed() { return floorCancelWhileMoving; }
 
+    public LiftArrivalLanternTriggerMode getArrivalLanternTriggerMode() {
+        return LiftArrivalLanternTriggerMode.fromSerializedName(arrivalLanternTriggerMode);
+    }
+
     public String getLiftNumber() { return liftNumber; }
 
     public void setSpeed(double speed) {
@@ -116,6 +134,10 @@ public class YteLiftConfig extends YteLiftConfigSchema {
 
     public void setFloorCancelWhileMovingAllowed(boolean floorCancelWhileMoving) {
         this.floorCancelWhileMoving = floorCancelWhileMoving;
+    }
+
+    public void setArrivalLanternTriggerMode(LiftArrivalLanternTriggerMode arrivalLanternTriggerMode) {
+        this.arrivalLanternTriggerMode = arrivalLanternTriggerMode.name();
     }
 
     public void setLiftNumber(String liftNumber) {

--- a/forge/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
+++ b/forge/src/main/java/top/xfunny/core/generated/data/YteLiftConfigSchema.java
@@ -20,6 +20,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     protected String doorButtonLightMode;
     protected String floorCancelMode;
     protected boolean floorCancelWhileMoving;
+    protected String arrivalLanternTriggerMode;
     protected String liftNumber;
 
     private static final String KEY_LIFT_ID = "lift_id";
@@ -36,6 +37,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     private static final String KEY_DOOR_BUTTON_LIGHT_MODE = "door_button_light_mode";
     private static final String KEY_FLOOR_CANCEL_MODE = "floor_cancel_mode";
     private static final String KEY_FLOOR_CANCEL_WHILE_MOVING = "floor_cancel_while_moving";
+    private static final String KEY_ARRIVAL_LANTERN_TRIGGER_MODE = "arrival_lantern_trigger_mode";
     private static final String KEY_LIFT_NUMBER = "lift_number";
 
     public static final double DEFAULT_SPEED = 10.0;
@@ -57,6 +59,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
     public static final String DEFAULT_MOTION_PROFILE = "STANDARD";
     public static final String DEFAULT_DOOR_BUTTON_LIGHT_MODE = "MOMENTARY";
     public static final String DEFAULT_FLOOR_CANCEL_MODE = "DOUBLE_CLICK";
+    public static final String DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE = "DECELERATION";
     public static final String DEFAULT_LIFT_NUMBER = "";
 
     protected YteLiftConfigSchema(long liftId, double speed, double acceleration, double adoDistance, double levellingDistance, double levellingSpeed) {
@@ -82,13 +85,24 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
             String motionProfile, boolean doorHoldEnabled) {
         this(liftId, speed, downSpeed, acceleration, downAcceleration, directionParametersLinked,
                 adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
-                DEFAULT_DOOR_BUTTON_LIGHT_MODE, DEFAULT_FLOOR_CANCEL_MODE, false, DEFAULT_LIFT_NUMBER);
+                DEFAULT_DOOR_BUTTON_LIGHT_MODE, DEFAULT_FLOOR_CANCEL_MODE, false,
+                DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE, DEFAULT_LIFT_NUMBER);
     }
 
     protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
             boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
             String motionProfile, boolean doorHoldEnabled, String doorButtonLightMode, String floorCancelMode,
             boolean floorCancelWhileMoving, String liftNumber) {
+        this(liftId, speed, downSpeed, acceleration, downAcceleration, directionParametersLinked,
+                adoDistance, levellingDistance, levellingSpeed, motionProfile, doorHoldEnabled,
+                doorButtonLightMode, floorCancelMode, floorCancelWhileMoving,
+                DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE, liftNumber);
+    }
+
+    protected YteLiftConfigSchema(long liftId, double speed, double downSpeed, double acceleration, double downAcceleration,
+            boolean directionParametersLinked, double adoDistance, double levellingDistance, double levellingSpeed,
+            String motionProfile, boolean doorHoldEnabled, String doorButtonLightMode, String floorCancelMode,
+            boolean floorCancelWhileMoving, String arrivalLanternTriggerMode, String liftNumber) {
         this.liftId = liftId;
         this.speed = speed;
         this.acceleration = acceleration;
@@ -103,6 +117,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         this.doorButtonLightMode = doorButtonLightMode;
         this.floorCancelMode = floorCancelMode;
         this.floorCancelWhileMoving = floorCancelWhileMoving;
+        this.arrivalLanternTriggerMode = arrivalLanternTriggerMode;
         this.liftNumber = liftNumber;
     }
 
@@ -120,6 +135,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         doorButtonLightMode = DEFAULT_DOOR_BUTTON_LIGHT_MODE;
         floorCancelMode = DEFAULT_FLOOR_CANCEL_MODE;
         floorCancelWhileMoving = false;
+        arrivalLanternTriggerMode = DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE;
         liftNumber = DEFAULT_LIFT_NUMBER;
         updateData(readerBase);
     }
@@ -140,6 +156,8 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         doorButtonLightMode = readerBase.getString(KEY_DOOR_BUTTON_LIGHT_MODE, DEFAULT_DOOR_BUTTON_LIGHT_MODE);
         floorCancelMode = readerBase.getString(KEY_FLOOR_CANCEL_MODE, DEFAULT_FLOOR_CANCEL_MODE);
         floorCancelWhileMoving = readerBase.getBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, false);
+        arrivalLanternTriggerMode = readerBase.getString(
+                KEY_ARRIVAL_LANTERN_TRIGGER_MODE, DEFAULT_ARRIVAL_LANTERN_TRIGGER_MODE);
         liftNumber = readerBase.getString(KEY_LIFT_NUMBER, DEFAULT_LIFT_NUMBER);
     }
 
@@ -159,6 +177,7 @@ public abstract class YteLiftConfigSchema implements SerializedDataBaseWithId {
         writerBase.writeString(KEY_DOOR_BUTTON_LIGHT_MODE, doorButtonLightMode);
         writerBase.writeString(KEY_FLOOR_CANCEL_MODE, floorCancelMode);
         writerBase.writeBoolean(KEY_FLOOR_CANCEL_WHILE_MOVING, floorCancelWhileMoving);
+        writerBase.writeString(KEY_ARRIVAL_LANTERN_TRIGGER_MODE, arrivalLanternTriggerMode);
         writerBase.writeString(KEY_LIFT_NUMBER, liftNumber);
     }
 


### PR DESCRIPTION
## 概述

为三菱 NexWay／菱电系列到站灯应用独立逻辑，并为后续不同品牌和 AIL 预报策略提供扩展接口。

## 三菱 NexWay／菱电逻辑

### 减速与到站

- 只对当前电梯的下一停靠楼层触发。
- 电梯进入减速时开始慢闪：700 ms 亮起 / 400 ms 熄灭。
- 触发时锁定本次到站的最终方向，避免后续其他楼层呼叫改写方向。
- 到站方向按最终停靠方向计算，顶层为下行，底层为上行。

### 开门、全开和关门

- 开门开始后切换为快闪：400 ms 亮起 / 300 ms 熄灭。
- 开门、全开和关门过程中都保持快闪。
- 门完全关闭后才熄灭。
- 上行、下行预报音按方向播放，同一次到站不重复触发。

### 同层呼叫

- 当电梯停在当前楼层且已开门时收到同层外呼，会使用同层呼叫方向触发到站灯。
- 有其他楼层或其他方向的新呼叫时，不会改变当前到站灯方向。

## AIL 接口预留

本 PR 不实现 AIL 群控预报逻辑。已预留：

- 被群控分配的电梯 ID。
- 等候楼层和呼叫方向。
- 分配时间。
- 预报音 cue。
- 通过 `LiftArrivalLanternAssignmentProvider` 扩展“按下按钮后仅被分配电梯长亮并播放预报音”。

## 通用策略接口

`LiftArrivalLanternPolicy` 可为每个品牌或到站灯型号提供独立策略。上下文可读取：

- 当前楼层、精确停层、下一停靠楼层。
- 当前速度、运行方向、减速、平层和剩余距离。
- 门值、开门和关门状态。
- 按键登记方向、登记时间和群控分配状态。

策略可返回：

- 灯光方向和到站阶段。
- 常亮、慢闪、快闪或自定义亮灭周期。
- 声音 cue。
- 事件序号，用于防止重复播放。

## 兼容性

- 旧电梯配置缺少新字段时默认使用减速触发。
- MP-VF 和其他品牌仍使用现有默认策略。
- 未修改 Gradle、构建脚本或任何构建配置。

## 测试

- Minecraft 1.20.1 Fabric 构建通过。
- Minecraft 1.20.1 Forge 构建通过。
- Minecraft 1.19.2 Fabric 构建通过。
- Minecraft 1.19.2 Forge 构建通过。
- `git merge-tree` 检查与最新 `main` 和当前开放的 Crowdin PR 均无冲突。
